### PR TITLE
Improve SPH ghost particle handling

### DIFF
--- a/ComponentFramework/SPHFluid3D.h
+++ b/ComponentFramework/SPHFluid3D.h
@@ -33,6 +33,7 @@ public:
     void RadixSortByCell();
     void ActivateClosestGhost(float x, float y, float z);
     void UpdateGhostParticlesDynamic(float h);
+    void UploadGhostActivityToGPU();
     void UploadDataToGPU();
     void DownloadDataFromGPU();
   

--- a/ComponentFramework/shaders/BuildGrid.comp
+++ b/ComponentFramework/shaders/BuildGrid.comp
@@ -1,7 +1,12 @@
 #version 450
 layout(local_size_x = 256) in;
 struct Particle {
-    vec4 pos; vec4 vel; vec4 acc; float density; float pressure; int isGhost; float pad0;
+    vec4 pos; vec4 vel; vec4 acc;
+    float density;
+    float pressure;
+    int isGhost;
+    float pad0;
+    int isActive;
 };
 layout(std430, binding = 0) buffer ParticleBuf { Particle particles[]; };
 layout(std430, binding = 1) buffer CellHeadBuf { int cellHead[]; };
@@ -12,6 +17,11 @@ uniform float cellSize;
 uniform float box;
 void main() {
     uint id = gl_GlobalInvocationID.x;
+    if (particles[id].isGhost == 1 && particles[id].isActive == 0) {
+        particleCell[id] = -1;
+        particleNext[id] = -1;
+        return;
+    }
     vec3 pos = particles[id].pos.xyz;
     ivec3 cellCoord = ivec3(floor((pos + vec3(box)) / cellSize));
     cellCoord = clamp(cellCoord, ivec3(0), gridSize - 1);

--- a/ComponentFramework/shaders/SPHFluid.comp
+++ b/ComponentFramework/shaders/SPHFluid.comp
@@ -62,6 +62,10 @@ void main() {
 
     // ---------- Ghost boundary handling ----------
     if (pi.isGhost == 1) {
+        if (pi.isActive == 0) {
+            particles[i] = pi;
+            return;
+        }
         pi.vel = vec4(0.0);
         pi.acc = vec4(0.0);
         pi.density = restDensity;


### PR DESCRIPTION
## Summary
- initialize `isActive` for all particles
- skip inactive ghosts when building the grid and in the SPH solver
- upload ghost activity flags each frame
- update compute dispatch to refresh active ghosts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685185d3afdc83268c620cbb35e93e4c