### PR TITLE
Improve compute shader bounds handling

### DIFF
--- a/ComponentFramework/ComponentFramework.vcxproj
+++ b/ComponentFramework/ComponentFramework.vcxproj
@@ -173,6 +173,8 @@
     <Text Include="GameEngineLog.txt" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="lineFrag.glsl" />
+    <None Include="lineVert.glsl" />
     <None Include="OBBConstraints.comp" />
     <None Include="shaders\BuildGrid.comp" />
     <None Include="shaders\ClearGrid.comp" />

--- a/ComponentFramework/ComponentFramework.vcxproj
+++ b/ComponentFramework/ComponentFramework.vcxproj
@@ -180,8 +180,11 @@
     <None Include="shaders\ClearGrid.comp" />
     <None Include="shaders\defaultFrag.glsl" />
     <None Include="shaders\defaultVert.glsl" />
+    <None Include="shaders\particleImpostor.frag" />
+    <None Include="shaders\particleImpostor.vert" />
     <None Include="shaders\RadixSort.comp" />
     <None Include="shaders\SPHFluid.comp" />
+    <None Include="shaders\WaveImpulse.comp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/ComponentFramework/ComponentFramework.vcxproj
+++ b/ComponentFramework/ComponentFramework.vcxproj
@@ -135,6 +135,7 @@
     <ClCompile Include="imgui_demo.cpp" />
     <ClCompile Include="imgui_draw.cpp" />
     <ClCompile Include="imgui_impl_opengl2.cpp" />
+    <ClCompile Include="imgui_impl_opengl3.cpp" />
     <ClCompile Include="imgui_impl_sdl2.cpp" />
     <ClCompile Include="imgui_tables.cpp" />
     <ClCompile Include="imgui_widgets.cpp" />
@@ -154,6 +155,7 @@
     <ClInclude Include="imconfig.h" />
     <ClInclude Include="imgui.h" />
     <ClInclude Include="imgui_impl_opengl2.h" />
+    <ClInclude Include="imgui_impl_opengl3.h" />
     <ClInclude Include="imgui_impl_opengl3_loader.h" />
     <ClInclude Include="imgui_impl_sdl2.h" />
     <ClInclude Include="Mesh.h" />
@@ -171,6 +173,7 @@
     <Text Include="GameEngineLog.txt" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="OBBConstraints.comp" />
     <None Include="shaders\BuildGrid.comp" />
     <None Include="shaders\ClearGrid.comp" />
     <None Include="shaders\defaultFrag.glsl" />

--- a/ComponentFramework/ComponentFramework.vcxproj.filters
+++ b/ComponentFramework/ComponentFramework.vcxproj.filters
@@ -171,5 +171,11 @@
     <None Include="OBBConstraints.comp">
       <Filter>Resource Files</Filter>
     </None>
+    <None Include="lineVert.glsl">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="lineFrag.glsl">
+      <Filter>Resource Files</Filter>
+    </None>
   </ItemGroup>
 </Project>

--- a/ComponentFramework/ComponentFramework.vcxproj.filters
+++ b/ComponentFramework/ComponentFramework.vcxproj.filters
@@ -177,5 +177,14 @@
     <None Include="lineFrag.glsl">
       <Filter>Resource Files</Filter>
     </None>
+    <None Include="shaders\particleImpostor.frag">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="shaders\particleImpostor.vert">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="shaders\WaveImpulse.comp">
+      <Filter>Resource Files</Filter>
+    </None>
   </ItemGroup>
 </Project>

--- a/ComponentFramework/ComponentFramework.vcxproj.filters
+++ b/ComponentFramework/ComponentFramework.vcxproj.filters
@@ -19,11 +19,11 @@
     <Filter Include="Source Files\Scenes">
       <UniqueIdentifier>{e8c82a08-d757-47ee-b6fe-eee59a99570f}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Ui">
-      <UniqueIdentifier>{6e00bbaa-d2ed-4a8e-b8d0-c96cbd563c75}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Source Files\Ui">
       <UniqueIdentifier>{62b3b8b4-f460-4aef-8af7-3da962337887}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Ui\Ui">
+      <UniqueIdentifier>{6e00bbaa-d2ed-4a8e-b8d0-c96cbd563c75}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -84,6 +84,9 @@
     <ClCompile Include="imgui_impl_opengl2.cpp">
       <Filter>Source Files\Ui</Filter>
     </ClCompile>
+    <ClCompile Include="imgui_impl_opengl3.cpp">
+      <Filter>Source Files\Ui</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Debug.h">
@@ -123,19 +126,22 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="imconfig.h">
-      <Filter>Ui</Filter>
+      <Filter>Source Files\Ui\Ui</Filter>
     </ClInclude>
     <ClInclude Include="imgui.h">
-      <Filter>Ui</Filter>
+      <Filter>Source Files\Ui\Ui</Filter>
     </ClInclude>
     <ClInclude Include="imgui_impl_opengl2.h">
-      <Filter>Ui</Filter>
+      <Filter>Source Files\Ui\Ui</Filter>
     </ClInclude>
     <ClInclude Include="imgui_impl_opengl3_loader.h">
-      <Filter>Ui</Filter>
+      <Filter>Source Files\Ui\Ui</Filter>
     </ClInclude>
     <ClInclude Include="imgui_impl_sdl2.h">
-      <Filter>Ui</Filter>
+      <Filter>Source Files\Ui\Ui</Filter>
+    </ClInclude>
+    <ClInclude Include="imgui_impl_opengl3.h">
+      <Filter>Source Files\Ui</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -160,6 +166,9 @@
       <Filter>Resource Files</Filter>
     </None>
     <None Include="shaders\ClearGrid.comp">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="OBBConstraints.comp">
       <Filter>Resource Files</Filter>
     </None>
   </ItemGroup>

--- a/ComponentFramework/GameEngineLog.txt
+++ b/ComponentFramework/GameEngineLog.txt
@@ -1,4 +1,4 @@
-Mon Jun 23 13:05:16 2025
+Thu Jul  3 22:46:49 2025
 [INFO]: Starting the SceneManager
 [INFO]: OpenGL version: 4.5.0 NVIDIA 576.52
 [INFO]: Graphics card vendor: NVIDIA Corporation

--- a/ComponentFramework/GameEngineLog.txt
+++ b/ComponentFramework/GameEngineLog.txt
@@ -1,4 +1,4 @@
-Tue Oct 14 14:40:06 2025
+Wed Oct 15 13:50:35 2025
 [INFO]: Starting the SceneManager
 [INFO]: OpenGL version: 4.5.0 NVIDIA 581.42
 [INFO]: Graphics card vendor: NVIDIA Corporation

--- a/ComponentFramework/GameEngineLog.txt
+++ b/ComponentFramework/GameEngineLog.txt
@@ -1,16 +1,16 @@
-Mon Sep 22 17:13:52 2025
+Mon Oct 13 17:10:27 2025
 [INFO]: Starting the SceneManager
-[INFO]: OpenGL version: 4.5.0 NVIDIA 581.29
+[INFO]: OpenGL version: 4.5.0 NVIDIA 581.42
 [INFO]: Graphics card vendor: NVIDIA Corporation
 [INFO]: Graphics card name: NVIDIA GeForce RTX 3060 Ti/PCIe/SSE2
 [INFO]: GLSL version: 4.50 NVIDIA
 [INFO]: Created Scene0: 
 [INFO]: Loading assets Scene0: 
 [INFO]: Uniforms:
-"modelMatrix" loc:0
-"projectionMatrix" loc:1
-"viewMatrix" loc:2
+"colorMode" loc:0
+"modelMatrix" loc:1
+"projectionMatrix" loc:2
+"useSSBO" loc:3
+"viewMatrix" loc:4
+"vizRange" loc:5
 
-[INFO]: Deleting the SceneManager
-[INFO]: Deleting assets Scene0: 
-[INFO]: Deleted Scene0: 

--- a/ComponentFramework/GameEngineLog.txt
+++ b/ComponentFramework/GameEngineLog.txt
@@ -1,4 +1,4 @@
-Mon Oct 13 17:10:27 2025
+Mon Oct 13 18:36:59 2025
 [INFO]: Starting the SceneManager
 [INFO]: OpenGL version: 4.5.0 NVIDIA 581.42
 [INFO]: Graphics card vendor: NVIDIA Corporation
@@ -14,3 +14,6 @@ Mon Oct 13 17:10:27 2025
 "viewMatrix" loc:4
 "vizRange" loc:5
 
+[INFO]: Deleting the SceneManager
+[INFO]: Deleting assets Scene0: 
+[INFO]: Deleted Scene0: 

--- a/ComponentFramework/GameEngineLog.txt
+++ b/ComponentFramework/GameEngineLog.txt
@@ -1,4 +1,4 @@
-Thu Jul  3 22:46:49 2025
+Sat Jul  5 16:27:06 2025
 [INFO]: Starting the SceneManager
 [INFO]: OpenGL version: 4.5.0 NVIDIA 576.52
 [INFO]: Graphics card vendor: NVIDIA Corporation

--- a/ComponentFramework/GameEngineLog.txt
+++ b/ComponentFramework/GameEngineLog.txt
@@ -1,4 +1,4 @@
-Tue Oct 14 13:10:46 2025
+Tue Oct 14 14:40:06 2025
 [INFO]: Starting the SceneManager
 [INFO]: OpenGL version: 4.5.0 NVIDIA 581.42
 [INFO]: Graphics card vendor: NVIDIA Corporation
@@ -20,7 +20,11 @@ Tue Oct 14 13:10:46 2025
 "viewMatrix" loc:2
 
 [INFO]: Uniforms:
-"projectionMatrix" loc:0
-"viewMatrix" loc:1
+"colorMode" loc:0
+"heightMinMax" loc:1
+"particleRadius" loc:2
+"projectionMatrix" loc:3
+"viewMatrix" loc:4
+"vizRange" loc:5
 
 [INFO]: Deleting the SceneManager

--- a/ComponentFramework/GameEngineLog.txt
+++ b/ComponentFramework/GameEngineLog.txt
@@ -1,4 +1,4 @@
-Mon Oct 13 21:10:12 2025
+Tue Oct 14 11:13:48 2025
 [INFO]: Starting the SceneManager
 [INFO]: OpenGL version: 4.5.0 NVIDIA 581.42
 [INFO]: Graphics card vendor: NVIDIA Corporation

--- a/ComponentFramework/GameEngineLog.txt
+++ b/ComponentFramework/GameEngineLog.txt
@@ -1,4 +1,4 @@
-Tue Jun 17 11:42:07 2025
+Tue Jun 17 12:02:05 2025
 [INFO]: Starting the SceneManager
 [INFO]: OpenGL version: 4.5.0 NVIDIA 576.52
 [INFO]: Graphics card vendor: NVIDIA Corporation
@@ -11,3 +11,6 @@ Tue Jun 17 11:42:07 2025
 "projectionMatrix" loc:1
 "viewMatrix" loc:2
 
+[INFO]: Deleting the SceneManager
+[INFO]: Deleting assets Scene0: 
+[INFO]: Deleted Scene0: 

--- a/ComponentFramework/GameEngineLog.txt
+++ b/ComponentFramework/GameEngineLog.txt
@@ -1,4 +1,4 @@
-Mon Oct 13 18:36:59 2025
+Mon Oct 13 21:10:12 2025
 [INFO]: Starting the SceneManager
 [INFO]: OpenGL version: 4.5.0 NVIDIA 581.42
 [INFO]: Graphics card vendor: NVIDIA Corporation
@@ -8,11 +8,17 @@ Mon Oct 13 18:36:59 2025
 [INFO]: Loading assets Scene0: 
 [INFO]: Uniforms:
 "colorMode" loc:0
-"modelMatrix" loc:1
-"projectionMatrix" loc:2
-"useSSBO" loc:3
-"viewMatrix" loc:4
-"vizRange" loc:5
+"heightMinMax" loc:1
+"modelMatrix" loc:2
+"projectionMatrix" loc:3
+"useSSBO" loc:4
+"viewMatrix" loc:5
+"vizRange" loc:6
+
+[INFO]: Uniforms:
+"projectionMatrix" loc:0
+"uColor" loc:1
+"viewMatrix" loc:2
 
 [INFO]: Deleting the SceneManager
 [INFO]: Deleting assets Scene0: 

--- a/ComponentFramework/GameEngineLog.txt
+++ b/ComponentFramework/GameEngineLog.txt
@@ -1,11 +1,10 @@
-Tue Oct 14 11:13:48 2025
+Tue Oct 14 13:10:46 2025
 [INFO]: Starting the SceneManager
 [INFO]: OpenGL version: 4.5.0 NVIDIA 581.42
 [INFO]: Graphics card vendor: NVIDIA Corporation
 [INFO]: Graphics card name: NVIDIA GeForce RTX 3060 Ti/PCIe/SSE2
 [INFO]: GLSL version: 4.50 NVIDIA
-[INFO]: Created Scene0: 
-[INFO]: Loading assets Scene0: 
+[INFO]: Loading assets Scene0p
 [INFO]: Uniforms:
 "colorMode" loc:0
 "heightMinMax" loc:1
@@ -20,6 +19,8 @@ Tue Oct 14 11:13:48 2025
 "uColor" loc:1
 "viewMatrix" loc:2
 
+[INFO]: Uniforms:
+"projectionMatrix" loc:0
+"viewMatrix" loc:1
+
 [INFO]: Deleting the SceneManager
-[INFO]: Deleting assets Scene0: 
-[INFO]: Deleted Scene0: 

--- a/ComponentFramework/GameEngineLog.txt
+++ b/ComponentFramework/GameEngineLog.txt
@@ -1,4 +1,4 @@
-Tue Jun 17 12:02:05 2025
+Tue Jun 17 13:29:13 2025
 [INFO]: Starting the SceneManager
 [INFO]: OpenGL version: 4.5.0 NVIDIA 576.52
 [INFO]: Graphics card vendor: NVIDIA Corporation

--- a/ComponentFramework/GameEngineLog.txt
+++ b/ComponentFramework/GameEngineLog.txt
@@ -1,6 +1,6 @@
-Sat Jul  5 16:27:06 2025
+Fri Sep 12 18:16:29 2025
 [INFO]: Starting the SceneManager
-[INFO]: OpenGL version: 4.5.0 NVIDIA 576.52
+[INFO]: OpenGL version: 4.5.0 NVIDIA 581.15
 [INFO]: Graphics card vendor: NVIDIA Corporation
 [INFO]: Graphics card name: NVIDIA GeForce RTX 3060 Ti/PCIe/SSE2
 [INFO]: GLSL version: 4.50 NVIDIA

--- a/ComponentFramework/GameEngineLog.txt
+++ b/ComponentFramework/GameEngineLog.txt
@@ -1,6 +1,6 @@
-Fri Sep 12 18:16:29 2025
+Mon Sep 22 17:13:52 2025
 [INFO]: Starting the SceneManager
-[INFO]: OpenGL version: 4.5.0 NVIDIA 581.15
+[INFO]: OpenGL version: 4.5.0 NVIDIA 581.29
 [INFO]: Graphics card vendor: NVIDIA Corporation
 [INFO]: Graphics card name: NVIDIA GeForce RTX 3060 Ti/PCIe/SSE2
 [INFO]: GLSL version: 4.50 NVIDIA

--- a/ComponentFramework/GameEngineLog.txt
+++ b/ComponentFramework/GameEngineLog.txt
@@ -1,4 +1,4 @@
-Tue Jun 17 13:29:13 2025
+Mon Jun 23 13:05:16 2025
 [INFO]: Starting the SceneManager
 [INFO]: OpenGL version: 4.5.0 NVIDIA 576.52
 [INFO]: Graphics card vendor: NVIDIA Corporation

--- a/ComponentFramework/Mesh.cpp
+++ b/ComponentFramework/Mesh.cpp
@@ -115,6 +115,8 @@ void Mesh::Render(GLenum drawmode_) const {
 void Mesh::RenderInstanced(GLenum drawmode_, size_t count) const {
     glBindVertexArray(vao);
     glDrawArraysInstanced(drawmode_, 0, dateLength, static_cast<GLsizei>(count));
+    GLenum err = glGetError();
+    if (err) std::cerr << "glDrawArraysInstanced error: 0x" << std::hex << err << std::dec << "\n";
     glBindVertexArray(0);
 }
 
@@ -136,10 +138,10 @@ void Mesh::SetInstanceData(const std::vector<Vec3>& positions) {
     glBindBuffer(GL_ARRAY_BUFFER, instanceVBO);
     glBufferData(GL_ARRAY_BUFFER, positions.size() * sizeof(Vec3), positions.data(), GL_DYNAMIC_DRAW);
 
-    // Attribute 3: instance position
-    glEnableVertexAttribArray(3);
-    glVertexAttribPointer(3, 3, GL_FLOAT, GL_FALSE, sizeof(Vec3), (void*)0);
-    glVertexAttribDivisor(3, 1); // Advance per instance
+    // Match defaultVert.glsl (instancePos is location = 5)
+    glEnableVertexAttribArray(5);
+    glVertexAttribPointer(5, 3, GL_FLOAT, GL_FALSE, sizeof(Vec3), (void*)0);
+    glVertexAttribDivisor(5, 1);
 
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     glBindVertexArray(0);

--- a/ComponentFramework/Mesh.cpp
+++ b/ComponentFramework/Mesh.cpp
@@ -121,15 +121,22 @@ void Mesh::RenderInstanced(GLenum drawmode_, size_t count) const {
 }
 
 void Mesh::BindInstanceBuffer(GLuint vbo, GLsizei stride) {
-    glBindVertexArray(this->vao);   // Your mesh's VAO
+    glBindVertexArray(this->vao);   // Mesh VAO
     glBindBuffer(GL_ARRAY_BUFFER, vbo);
-    glEnableVertexAttribArray(5);   // Choose location 4, for example
+
+    // Per-instance position (vec4) at location 5
+    glEnableVertexAttribArray(5);
     glVertexAttribPointer(5, 4, GL_FLOAT, GL_FALSE, stride, (void*)0);
-    glVertexAttribDivisor(5, 1);    // Advance once per instance
+    glVertexAttribDivisor(5, 1); // advance once per instance
+
+    // Explicitly keep optional instance attrs disabled unless provided
+    glDisableVertexAttribArray(4); // optional color
+    glDisableVertexAttribArray(6); // optional velocity
+
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     glBindVertexArray(0);
-	//std::cout << "Instance buffer bound to VAO: " << vao << " with VBO: " << vbo << std::endl;
-} 
+}
+
 void Mesh::SetInstanceData(const std::vector<Vec3>& positions) {
     if (instanceVBO == 0) {
         glGenBuffers(1, &instanceVBO);

--- a/ComponentFramework/OBBConstraints.comp
+++ b/ComponentFramework/OBBConstraints.comp
@@ -1,0 +1,50 @@
+#version 450
+layout(local_size_x = 256) in;
+
+struct Particle {
+    vec4 pos; vec4 vel; vec4 acc;
+    float density; float pressure; float padA; float padB;
+    int isGhost; int isActive; int padC; int pad0;
+};
+layout(std430, binding=0) buffer Particles { Particle particles[]; };
+
+uniform vec3 uBoxCenter;
+uniform vec3 uBoxHalf;
+uniform mat3 uBoxRot;
+uniform float uRestitution;
+uniform float uFriction;
+
+vec3 worldToLocal(vec3 p){ vec3 d = p - uBoxCenter; return vec3(dot(d,uBoxRot[0]), dot(d,uBoxRot[1]), dot(d,uBoxRot[2])); }
+vec3 localToWorld(vec3 q){ return uBoxCenter + uBoxRot * q; }
+
+void main() {
+    uint i = gl_GlobalInvocationID.x;
+    if (i >= particles.length()) return;
+    if (particles[i].isGhost != 0) return;
+
+    vec3 pW = particles[i].pos.xyz;
+    vec3 vW = particles[i].vel.xyz;
+
+    vec3 pL = worldToLocal(pW);
+    vec3 qL = clamp(pL, -uBoxHalf, uBoxHalf);
+    vec3 delta = pL - qL;
+
+    if (any(greaterThan(abs(delta), vec3(0.0)))) {
+        vec3 nL = vec3(0.0);
+        vec3 d = abs(delta);
+        if (d.x >= d.y && d.x >= d.z) nL = vec3(sign(delta.x), 0.0, 0.0);
+        else if (d.y >= d.x && d.y >= d.z) nL = vec3(0.0, sign(delta.y), 0.0);
+        else nL = vec3(0.0, 0.0, sign(delta.z));
+
+        vec3 nW = normalize(uBoxRot * nL);
+        pW = localToWorld(qL);
+
+        float vn = dot(vW, nW);
+        vec3 vN = vn * nW;
+        vec3 vT = vW - vN;
+        vW = -uRestitution * vN + (1.0 - uFriction) * vT;
+    }
+
+    particles[i].pos.xyz = pW;
+    particles[i].vel.xyz = vW;
+}

--- a/ComponentFramework/SPHFluid3D.cpp
+++ b/ComponentFramework/SPHFluid3D.cpp
@@ -309,9 +309,9 @@ void SPHFluidGPU::DispatchCompute() {
     float restDensity = mass / (spacing * spacing * spacing); // ≈ 370     // mass / (spacing^3)
     float gasConstant = 15000.0f;
     float viscosity = 3.0f;
-    MATH::Vec3 gravity = MATH::Vec3(0, -980.0f, 0);
+    MATH::Vec3 gravity = MATH::Vec3(0, -980000.0f, 0);
     float surfaceTension = 0.5f;
-    float timeStep = 0.002f;
+    float timeStep = 0.001f;
 
     UpdateGhostParticlesDynamic(h);
     UploadGhostActivityToGPU();

--- a/ComponentFramework/SPHFluid3D.cpp
+++ b/ComponentFramework/SPHFluid3D.cpp
@@ -6,16 +6,11 @@
 #include <vector>
 #include <iostream>
 #include <cmath>
+#include <limits>
 #include <SDL_stdinc.h>
 #include <algorithm>
 
-static void Mul3x3(const float A[9], const float B[9], float C[9]) {
-    for (int c = 0; c < 3; c++)
-        for (int r = 0; r < 3; r++)
-            C[c * 3 + r] = A[0 * 3 + r] * B[c * 3 + 0] + A[1 * 3 + r] * B[c * 3 + 1] + A[2 * 3 + r] * B[c * 3 + 2];
-}
-
-void SPHFluid3D::MakeRotationMat3XYZ(float rxDeg, float ryDeg, float rzDeg, float outM[9]) {
+static void MakeRotationMat3XYZ(float rxDeg, float ryDeg, float rzDeg, float outM[9]) {
     const float rx = rxDeg * float(M_PI / 180.0);
     const float ry = ryDeg * float(M_PI / 180.0);
     const float rz = rzDeg * float(M_PI / 180.0);
@@ -25,8 +20,13 @@ void SPHFluid3D::MakeRotationMat3XYZ(float rxDeg, float ryDeg, float rzDeg, floa
     const float Rz[9] = { cz, sz, 0, -sz, cz, 0, 0, 0, 1 };
     const float Ry[9] = { cy, 0, -sy, 0, 1, 0, sy, 0, cy };
     const float Rx[9] = { 1, 0, 0, 0, cx, sx, 0, -sx, cx };
-    float Rzy[9]; Mul3x3(Rz, Ry, Rzy);
-    Mul3x3(Rzy, Rx, outM);
+    auto mul3 = [](const float A[9], const float B[9], float C[9]) {
+        for (int c = 0; c < 3; ++c)
+            for (int r = 0; r < 3; ++r)
+                C[c * 3 + r] = A[0 * 3 + r] * B[c * 3 + 0] + A[1 * 3 + r] * B[c * 3 + 1] + A[2 * 3 + r] * B[c * 3 + 2];
+        };
+    float Rzy[9]; mul3(Rz, Ry, Rzy);
+    mul3(Rzy, Rx, outM);
 }
 
 SPHFluidGPU::SPHFluidGPU(size_t numParticles_)
@@ -39,22 +39,16 @@ SPHFluidGPU::SPHFluidGPU(size_t numParticles_)
     obbConstraintShader = LoadComputeShader("shaders/OBBConstraints.comp");
     waveImpulseShader = LoadComputeShader("shaders/WaveImpulse.comp"); // NEW
 
-    // 1) Build particles (also sets 'box')
+    // 1) Build particle array (also sets 'box' from OBB half)
     InitializeParticles();
 
-    // 2) Now size grid/aux SSBOs using the actual particle count
+    // 2) Size grid/aux SSBOs from particles.size()
     InitializeGridAndBuffers();
-    InitializeSortBuffers();
 
-    // 3) GPU resources
+    // 3) Upload particles SSBO + sort buffers + VBO
     UploadDataToGPU();
+    InitializeSortBuffers();
     InitializeFluidVBO();
-
-    // Cache OBB rotation once
-    cachedBoxCenter = param_boxCenter;
-    cachedBoxHalf = param_boxHalf;
-    cachedBoxEuler = param_boxEulerDeg;
-    MakeRotationMat3XYZ(cachedBoxEuler.x, cachedBoxEuler.y, cachedBoxEuler.z, cachedRot3x3);
 }
 
 SPHFluidGPU::~SPHFluidGPU() {
@@ -81,22 +75,24 @@ void SPHFluidGPU::InitializeParticles() {
     float spacing = h * 0.85f;
     float box = this->box;
 
+    param_mass = param_restDensity * spacing * spacing * spacing;
+
     particles.clear();
     int count = 0;
 
-    const float fillFraction = 0.4f;
-    const float fluidHeight = (2.0f * box) * fillFraction;
-    const int fluidLayersY = int(fluidHeight / spacing);
-    const int fluidSide = int((box * 1.7f) / spacing);
+    float fillFraction = 0.4f;
+    float fluidHeight = (2.0f * box) * fillFraction;
+    int   fluidLayersY = int(fluidHeight / spacing);
+    int   fluidSide = int((box * 1.7f) / spacing);
 
     std::default_random_engine rng(static_cast<unsigned>(time(nullptr)));
     std::uniform_real_distribution<float> jitterDist(-spacing * param_jitterAmp,
         +spacing * param_jitterAmp);
     auto j = [&]() -> float { return param_useJitter ? jitterDist(rng) : 0.0f; };
 
-    // Fill a block at the bottom of the box
-    for (int x = 0; x < fluidSide && count < (int)numParticles; ++x) {
-        for (int y = 0; y < fluidLayersY && count < (int)numParticles; ++y) {
+    // Fill a block at the bottom
+    for (int x = 0; x < fluidSide && count < (int)numParticles; ++x)
+        for (int y = 0; y < fluidLayersY && count < (int)numParticles; ++y)
             for (int z = 0; z < fluidSide && count < (int)numParticles; ++z) {
                 SPHParticle p{};
                 p.pos = Vec4(-box * 0.7f + x * spacing + j(),
@@ -104,34 +100,138 @@ void SPHFluidGPU::InitializeParticles() {
                     -box * 0.7f + z * spacing + j(), 0.0f);
                 p.vel = Vec4(0, 0, 0, 0);
                 p.acc = Vec4(0, 0, 0, 0);
-                p.density = 0.0f; p.pressure = 0.0f;
-                p.isGhost = 0; p.isActive = 0;
-                particles.push_back(p);
-                ++count;
+                p.density = p.pressure = 0.0f;
+                p.isGhost = 0; p.isActive = 0; p.pad0 = 0;
+                particles.push_back(p); ++count;
             }
-        }
-    }
 
-    // Boundary ghosts
+    // Create axis-aligned ghost shell (used if param_enableGhosts is true)
     auto add_ghost = [&](float x, float y, float z) {
         SPHParticle p{};
         p.pos = Vec4(x, y, z, 0); p.vel = Vec4(0, 0, 0, 0); p.acc = Vec4(0, 0, 0, 0);
-        p.density = 0; p.pressure = 0; p.isGhost = 1; p.isActive = 0;
+        p.density = p.pressure = 0.0f; p.isGhost = 1; p.isActive = 0; p.pad0 = 0;
         particles.push_back(p);
         };
-    for (float y = -box; y <= box; y += spacing)
-        for (float z = -box; z <= box; z += spacing) { add_ghost(-box, y, z); add_ghost(box, y, z); }
-    for (float x = -box; x <= box; x += spacing)
-        for (float z = -box; z <= box; z += spacing) { add_ghost(x, -box, z); add_ghost(x, box, z); }
-    for (float x = -box; x <= box; x += spacing)
-        for (float y = -box; y <= box; y += spacing) { add_ghost(x, y, -box); add_ghost(x, y, box); }
+    for (float y = -box; y <= box; y += spacing) for (float z = -box; z <= box; z += spacing) { add_ghost(-box, y, z); add_ghost(box, y, z); }
+    for (float x = -box; x <= box; x += spacing) for (float z = -box; z <= box; z += spacing) { add_ghost(x, -box, z); add_ghost(x, box, z); }
+    for (float x = -box; x <= box; x += spacing) for (float y = -box; y <= box; y += spacing) { add_ghost(x, y, -box); add_ghost(x, y, box); }
 
     std::cout << "Fluid particles: " << count
         << ", ghosts: " << (particles.size() - count) << std::endl;
+    BuildGhostGrids(); 
 
-    BuildGhostGrids();
+    
 }
 
+void SPHFluidGPU::BuildGhostGrids() {
+    // Build 2D uniform grids on each AABB face (-X,+X,-Y,+Y,-Z,+Z)
+    // Faces are still axis-aligned even if an OBB is used for constraints (ghost shell made AABB).
+    const float hx = param_boxHalf.x;
+    const float hy = param_boxHalf.y;
+    const float hz = param_boxHalf.z;
+    const float faceCell = param_h; // use smoothing length for ghost grid resolution
+
+    auto makeDim = [&](float extent) -> int {
+        int c = int(std::ceil((2.0f * extent) / faceCell));
+        return std::max(1, c);
+        };
+
+    int cellsY = makeDim(hy);
+    int cellsZ = makeDim(hz);
+    int cellsX = makeDim(hx);
+
+    ghostXNeg.init(-hy, -hz, faceCell, cellsY, cellsZ); // a=y, b=z
+    ghostXPos.init(-hy, -hz, faceCell, cellsY, cellsZ);
+    ghostYNeg.init(-hx, -hz, faceCell, cellsX, cellsZ); // a=x, b=z
+    ghostYPos.init(-hx, -hz, faceCell, cellsX, cellsZ);
+    ghostZNeg.init(-hx, -hy, faceCell, cellsX, cellsY); // a=x, b=y
+    ghostZPos.init(-hx, -hy, faceCell, cellsX, cellsY);
+
+    const float eps = faceCell * 0.25f;
+
+    for (size_t i = 0; i < particles.size(); ++i) {
+        const SPHParticle& p = particles[i];
+        if (!p.isGhost) continue;
+
+        const float x = p.pos.x;
+        const float y = p.pos.y;
+        const float z = p.pos.z;
+
+        // Face tests (AABB shell built with 'box' == max half but we rely on param_boxHalf per axis)
+        if (std::fabs(x + hx) < eps)      ghostXNeg.addGhost(y, z, i);
+        else if (std::fabs(x - hx) < eps) ghostXPos.addGhost(y, z, i);
+
+        if (std::fabs(y + hy) < eps)      ghostYNeg.addGhost(x, z, i);
+        else if (std::fabs(y - hy) < eps) ghostYPos.addGhost(x, z, i);
+
+        if (std::fabs(z + hz) < eps)      ghostZNeg.addGhost(x, y, i);
+        else if (std::fabs(z - hz) < eps) ghostZPos.addGhost(x, y, i);
+    }
+
+    std::cout << "Ghost grids built: "
+        << " X(-/+) cells=" << ghostXNeg.cellsA << "x" << ghostXNeg.cellsB
+        << " Y(-/+) cells=" << ghostYNeg.cellsA << "x" << ghostYNeg.cellsB
+        << " Z(-/+) cells=" << ghostZNeg.cellsA << "x" << ghostZNeg.cellsB
+        << std::endl;
+}
+
+/* Optional simple usage helpers (keep lightweight) */
+
+void SPHFluidGPU::ActivateClosestGhost(float x, float y, float z) {
+    // Pick nearest face to (x,y,z), then search that face grid cell for closest ghost
+    float dxNeg = std::fabs(x + param_boxHalf.x);
+    float dxPos = std::fabs(x - param_boxHalf.x);
+    float dyNeg = std::fabs(y + param_boxHalf.y);
+    float dyPos = std::fabs(y - param_boxHalf.y);
+    float dzNeg = std::fabs(z + param_boxHalf.z);
+    float dzPos = std::fabs(z - param_boxHalf.z);
+
+    enum Face { XN, XP, YN, YP, ZN, ZP };
+    float dArr[6] = { dxNeg, dxPos, dyNeg, dyPos, dzNeg, dzPos };
+    Face best = XN;
+    float bestD = dArr[0];
+    for (int i = 1; i < 6; ++i) if (dArr[i] < bestD) { bestD = dArr[i]; best = (Face)i; }
+
+    const std::vector<size_t>* candidates = nullptr;
+    switch (best) {
+    case XN: candidates = &ghostXNeg.getCell(y, z); break;
+    case XP: candidates = &ghostXPos.getCell(y, z); break;
+    case YN: candidates = &ghostYNeg.getCell(x, z); break;
+    case YP: candidates = &ghostYPos.getCell(x, z); break;
+    case ZN: candidates = &ghostZNeg.getCell(x, y); break;
+    case ZP: candidates = &ghostZPos.getCell(x, y); break;
+    }
+    if (!candidates || candidates->empty()) return;
+
+    size_t closestIdx = (*candidates)[0];
+    float closestDist2 = FLT_MAX;
+    for (size_t idx : *candidates) {
+        const SPHParticle& gp = particles[idx];
+        float dx = gp.pos.x - x;
+        float dy = gp.pos.y - y;
+        float dz = gp.pos.z - z;
+        float d2 = dx * dx + dy * dy + dz * dz;
+        if (d2 < closestDist2) { closestDist2 = d2; closestIdx = idx; }
+    }
+    particles[closestIdx].isActive = 1;
+}
+
+void SPHFluidGPU::UpdateGhostParticlesDynamic(float h) {
+    // Simple decay: deactivate ghosts set active last frame (placeholder)
+    for (auto& p : particles) if (p.isGhost) p.isActive = 0;
+    (void)h;
+}
+
+void SPHFluidGPU::UploadGhostActivityToGPU() {
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, ssbo);
+    SPHParticle* gpuParticles = (SPHParticle*)glMapBuffer(GL_SHADER_STORAGE_BUFFER, GL_READ_WRITE);
+    if (gpuParticles) {
+        for (size_t i = 0; i < particles.size(); ++i)
+            gpuParticles[i].isActive = particles[i].isActive;
+    }
+    glUnmapBuffer(GL_SHADER_STORAGE_BUFFER);
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
+}
 void SPHFluidGPU::InitializeFluidVBO() {
     numFluids = 0;
     for (const auto& p : particles) if (p.isGhost == 0) ++numFluids;
@@ -141,7 +241,6 @@ void SPHFluidGPU::InitializeFluidVBO() {
     glBindBuffer(GL_ARRAY_BUFFER, fluidVBO);
     glBufferStorage(GL_ARRAY_BUFFER, sizeof(float) * 4 * numFluids, nullptr,
         GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT);
-
     vboPtr = (float*)glMapBufferRange(GL_ARRAY_BUFFER, 0, sizeof(float) * 4 * numFluids,
         GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT);
     glBindBuffer(GL_ARRAY_BUFFER, 0);
@@ -151,14 +250,14 @@ void SPHFluidGPU::UpdateFluidVBOFromGPU() {
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, ssbo);
     const SPHParticle* gpuParticles = (const SPHParticle*)glMapBuffer(GL_SHADER_STORAGE_BUFFER, GL_READ_ONLY);
     if (gpuParticles && vboPtr) {
-        size_t v = 0;
+        size_t vboIndex = 0;
         for (size_t i = 0; i < particles.size(); ++i) {
             if (gpuParticles[i].isGhost == 0) {
-                vboPtr[4 * v + 0] = gpuParticles[i].pos.x;
-                vboPtr[4 * v + 1] = gpuParticles[i].pos.y;
-                vboPtr[4 * v + 2] = gpuParticles[i].pos.z;
-                vboPtr[4 * v + 3] = 1.0f;
-                ++v;
+                vboPtr[4 * vboIndex + 0] = gpuParticles[i].pos.x;
+                vboPtr[4 * vboIndex + 1] = gpuParticles[i].pos.y;
+                vboPtr[4 * vboIndex + 2] = gpuParticles[i].pos.z;
+                vboPtr[4 * vboIndex + 3] = 1.0f;
+                ++vboIndex;
             }
         }
     }
@@ -171,10 +270,10 @@ void SPHFluidGPU::InitializeGridAndBuffers() {
     cellSize = h;
 
     Vec3 half = param_boxHalf;
-    gridSizeX = std::max(1, int(ceil((2.0f * half.x) / cellSize)));
-    gridSizeY = std::max(1, int(ceil((2.0f * half.y) / cellSize)));
-    gridSizeZ = std::max(1, int(ceil((2.0f * half.z) / cellSize)));
-    numCells = gridSizeX * gridSizeY * gridSizeZ;
+    gridSizeX = std::max(1, int(std::ceil((2.0f * half.x) / cellSize)));
+    gridSizeY = std::max(1, int(std::ceil((2.0f * half.y) / cellSize)));
+    gridSizeZ = std::max(1, int(std::ceil((2.0f * half.z) / cellSize)));
+    numCells = std::max(1, gridSizeX * gridSizeY * gridSizeZ);
 
     box = std::max(half.x, std::max(half.y, half.z));
 
@@ -205,9 +304,9 @@ void SPHFluidGPU::InitializeGridAndBuffers() {
 
 void SPHFluidGPU::RecreateGridForBox() { InitializeGridAndBuffers(); }
 
+// --- sorting buffers
 void SPHFluidGPU::InitializeSortBuffers() {
     size_t N = particles.size();
-
     glGenBuffers(1, &cellKeySSBO);
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, cellKeySSBO);
     glBufferData(GL_SHADER_STORAGE_BUFFER, sizeof(int) * N, nullptr, GL_DYNAMIC_COPY);
@@ -222,27 +321,18 @@ void SPHFluidGPU::InitializeSortBuffers() {
     glBufferData(GL_SHADER_STORAGE_BUFFER, sizeof(int) * N, nullptr, GL_DYNAMIC_COPY);
 }
 
-void SPHFluidGPU::RadixSortByCell() {
-    size_t N = particles.size();
-    for (int pass = 0; pass < 8; ++pass) {
-        glUseProgram(radixSortShader);
-        glUniform1i(glGetUniformLocation(radixSortShader, "N"), int(N));
-        glUniform1i(glGetUniformLocation(radixSortShader, "pass"), pass);
-        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, cellKeySSBO);
-        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, (pass % 2 == 0) ? sortIdxSSBO : sortTmpSSBO);
-        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 2, (pass % 2 == 0) ? sortTmpSSBO : sortIdxSSBO);
-        glDispatchCompute((N + 255) / 256, 1, 1);
-        glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
-    }
-}
-
 void SPHFluidGPU::UploadDataToGPU() {
     glGenBuffers(1, &ssbo);
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, ssbo);
     const GLsizeiptr sz = sizeof(SPHParticle) * particles.size();
     glBufferData(GL_SHADER_STORAGE_BUFFER, sz, particles.data(), GL_DYNAMIC_COPY);
+
+    GLint64 gpuSize = 0; glGetBufferParameteri64v(GL_SHADER_STORAGE_BUFFER, GL_BUFFER_SIZE, &gpuSize);
+    if (gpuSize != sz) std::cerr << "SSBO size mismatch: " << gpuSize << " vs " << sz << "\n";
+
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, ssbo);
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
+    std::cout << "sizeof(SPHParticle)=" << sizeof(SPHParticle) << " bytes\n";
 }
 
 void SPHFluidGPU::DownloadDataFromGPU() {
@@ -255,34 +345,15 @@ void SPHFluidGPU::DownloadDataFromGPU() {
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
 }
 
-void SPHFluidGPU::UpdateCachedBoxIfNeeded() {
-    if (cachedBoxCenter.x != param_boxCenter.x || cachedBoxCenter.y != param_boxCenter.y || cachedBoxCenter.z != param_boxCenter.z ||
-        cachedBoxHalf.x != param_boxHalf.x || cachedBoxHalf.y != param_boxHalf.y || cachedBoxHalf.z != param_boxHalf.z ||
-        cachedBoxEuler.x != param_boxEulerDeg.x || cachedBoxEuler.y != param_boxEulerDeg.y || cachedBoxEuler.z != param_boxEulerDeg.z) {
-        cachedBoxCenter = param_boxCenter;
-        cachedBoxHalf = param_boxHalf;
-        cachedBoxEuler = param_boxEulerDeg;
-        MakeRotationMat3XYZ(cachedBoxEuler.x, cachedBoxEuler.y, cachedBoxEuler.z, cachedRot3x3);
-    }
-}
-
-void SPHFluidGPU::DispatchCompute() {
+void SPHFluidGPU::DispatchCompute(float overrideDt) {
     if (param_pause) return;
 
-    // Live params
-    float h = param_h;
-    float mass = param_mass;
-    float restDensity = param_restDensity;
-    float gasConstant = param_gasConstant;
-    float viscosity = param_viscosity;
-    Vec3  gravity = Vec3(0, param_gravityY, 0);
-    float surfaceTension = param_surfaceTension;
-    float timeStep = param_timeStep;
+    const float timeStep = (overrideDt > 0.0f ? overrideDt : param_timeStep);
 
-    // No CPU ghost activation in fast path
+    // Optional ghost syncing (leave off for perf)
     if (param_enableGhosts) {
         DownloadDataFromGPU();
-        UpdateGhostParticlesDynamic(h);
+        UpdateGhostParticlesDynamic(param_h);
         UploadGhostActivityToGPU();
     }
 
@@ -316,13 +387,14 @@ void SPHFluidGPU::DispatchCompute() {
     glUniform1f(glGetUniformLocation(sphGridShader, "cellSize"), cellSize);
     glUniform1i(glGetUniformLocation(sphGridShader, "numParticles"), int(particles.size()));
     glUniform1f(glGetUniformLocation(sphGridShader, "timeStep"), timeStep);
-    glUniform1f(glGetUniformLocation(sphGridShader, "h"), h);
-    glUniform1f(glGetUniformLocation(sphGridShader, "mass"), mass);
-    glUniform1f(glGetUniformLocation(sphGridShader, "restDensity"), restDensity);
-    glUniform1f(glGetUniformLocation(sphGridShader, "gasConstant"), gasConstant);
-    glUniform1f(glGetUniformLocation(sphGridShader, "viscosity"), viscosity);
-    glUniform3f(glGetUniformLocation(sphGridShader, "gravity"), gravity.x, gravity.y, gravity.z);
-    glUniform1f(glGetUniformLocation(sphGridShader, "surfaceTension"), surfaceTension);
+    glUniform1f(glGetUniformLocation(sphGridShader, "h"), param_h);
+    glUniform1f(glGetUniformLocation(sphGridShader, "mass"), param_mass);
+    glUniform1f(glGetUniformLocation(sphGridShader, "restDensity"), param_restDensity);
+    glUniform1f(glGetUniformLocation(sphGridShader, "gasConstant"), param_gasConstant);
+    glUniform1f(glGetUniformLocation(sphGridShader, "viscosity"), param_viscosity);
+    glUniform3f(glGetUniformLocation(sphGridShader, "gravity"), 0.0f, param_gravityY, 0.0f);
+    glUniform1f(glGetUniformLocation(sphGridShader, "surfaceTension"), param_surfaceTension);
+    glUniform1f(glGetUniformLocation(sphGridShader, "box"), box);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, ssbo);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, cellHeadSSBO);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 2, particleNextSSBO);
@@ -330,14 +402,12 @@ void SPHFluidGPU::DispatchCompute() {
     glDispatchCompute((particles.size() + 255) / 256, 1, 1);
     glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
 
-    // 4) OBB constraints (use cached rotation)
-    UpdateCachedBoxIfNeeded();
+    // 4) OBB constraints
     glUseProgram(obbConstraintShader);
-    glUniformMatrix3fv(glGetUniformLocation(obbConstraintShader, "uBoxRot"), 1, GL_FALSE, cachedRot3x3);
-    glUniform3f(glGetUniformLocation(obbConstraintShader, "uBoxCenter"),
-        param_boxCenter.x, param_boxCenter.y, param_boxCenter.z);
-    glUniform3f(glGetUniformLocation(obbConstraintShader, "uBoxHalf"),
-        param_boxHalf.x, param_boxHalf.y, param_boxHalf.z);
+    float R[9]; MakeRotationMat3XYZ(param_boxEulerDeg.x, param_boxEulerDeg.y, param_boxEulerDeg.z, R);
+    glUniformMatrix3fv(glGetUniformLocation(obbConstraintShader, "uBoxRot"), 1, GL_FALSE, R);
+    glUniform3f(glGetUniformLocation(obbConstraintShader, "uBoxCenter"), param_boxCenter.x, param_boxCenter.y, param_boxCenter.z);
+    glUniform3f(glGetUniformLocation(obbConstraintShader, "uBoxHalf"), param_boxHalf.x, param_boxHalf.y, param_boxHalf.z);
     glUniform1f(glGetUniformLocation(obbConstraintShader, "uRestitution"), param_wallRestitution);
     glUniform1f(glGetUniformLocation(obbConstraintShader, "uFriction"), param_wallFriction);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, ssbo);
@@ -347,85 +417,120 @@ void SPHFluidGPU::DispatchCompute() {
     glUseProgram(0);
 }
 
-void SPHFluidGPU::ApplyWaveImpulseGPU(float amplitude, float wavelength, float phase,
-    const Vec3& dir, float yMin, float yMax)
+GLuint SPHFluidGPU::GetFluidVBO() const { return fluidVBO; }
+size_t SPHFluidGPU::GetNumFluids() const { return numFluids; }
+
+// --- GPU-only WaveImpulse (replaces CPU readback path)
+void SPHFluidGPU::ApplyWaveImpulse(float amplitude, float wavelength, float phase, const Vec3& dir,
+    float yMin, float yMax)
 {
     if (amplitude == 0.0f || wavelength <= 1e-6f) return;
+
     glUseProgram(waveImpulseShader);
+    glUniform1i(glGetUniformLocation(waveImpulseShader, "N"), int(particles.size()));
     glUniform1f(glGetUniformLocation(waveImpulseShader, "amplitude"), amplitude);
     glUniform1f(glGetUniformLocation(waveImpulseShader, "wavelength"), wavelength);
     glUniform1f(glGetUniformLocation(waveImpulseShader, "phase"), phase);
+    // normalize dir on GPU (shader can do it), but pass anyway
     glUniform3f(glGetUniformLocation(waveImpulseShader, "dir"), dir.x, dir.y, dir.z);
     glUniform1f(glGetUniformLocation(waveImpulseShader, "yMin"), yMin);
     glUniform1f(glGetUniformLocation(waveImpulseShader, "yMax"), yMax);
+
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, ssbo);
     glDispatchCompute((particles.size() + 255) / 256, 1, 1);
-    glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT); // velocities used next SPH step
+    glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
     glUseProgram(0);
 }
 
-GLuint SPHFluidGPU::GetFluidVBO()  const { return fluidVBO; }
-size_t SPHFluidGPU::GetNumFluids() const { return numFluids; }
+// Full reset (unchanged logic, grouped)
+void SPHFluidGPU::ResetSimulation() {
+    if (fluidVBO) { glBindBuffer(GL_ARRAY_BUFFER, 0); glDeleteBuffers(1, &fluidVBO); fluidVBO = 0; vboPtr = nullptr; }
+    if (ssbo) { glDeleteBuffers(1, &ssbo); ssbo = 0; }
+    if (cellHeadSSBO) { glDeleteBuffers(1, &cellHeadSSBO);     cellHeadSSBO = 0; }
+    if (particleNextSSBO) { glDeleteBuffers(1, &particleNextSSBO); particleNextSSBO = 0; }
+    if (particleCellSSBO) { glDeleteBuffers(1, &particleCellSSBO); particleCellSSBO = 0; }
+    if (cellKeySSBO) { glDeleteBuffers(1, &cellKeySSBO);      cellKeySSBO = 0; }
+    if (sortIdxSSBO) { glDeleteBuffers(1, &sortIdxSSBO);      sortIdxSSBO = 0; }
+    if (sortTmpSSBO) { glDeleteBuffers(1, &sortTmpSSBO);      sortTmpSSBO = 0; }
 
+    InitializeParticles();
+    InitializeGridAndBuffers();
+    UploadDataToGPU();
+    InitializeSortBuffers();
+    InitializeFluidVBO();
+
+    std::cout << "Reset: particles=" << particles.size()
+        << " fluids=" << numFluids
+        << " grid=" << gridSizeX << "x" << gridSizeY << "x" << gridSizeZ
+        << " cells=" << numCells << std::endl;
+}
+
+void SPHFluidGPU::RadixSortByCell() {
+    // Map buffers
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, cellKeySSBO);
+    const int* keys = (const int*)glMapBuffer(GL_SHADER_STORAGE_BUFFER, GL_READ_ONLY);
+    if (!keys) { glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0); return; }
+
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, sortIdxSSBO);
+    int* indices = (int*)glMapBuffer(GL_SHADER_STORAGE_BUFFER, GL_READ_WRITE);
+    if (!indices) {
+        glUnmapBuffer(GL_SHADER_STORAGE_BUFFER); // keys
+        glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
+        return;
+    }
+
+    size_t N = particles.size();
+    // Build vector of (key,index) then stable sort
+    std::vector<std::pair<int, int>> kv;
+    kv.reserve(N);
+    for (size_t i = 0; i < N; ++i) kv.emplace_back(keys[i], indices[i]);
+
+    std::stable_sort(kv.begin(), kv.end(),
+        [](const std::pair<int, int>& a, const std::pair<int, int>& b) {
+            return a.first < b.first;
+        });
+
+    // Write back sorted indices
+    for (size_t i = 0; i < N; ++i) indices[i] = kv[i].second;
+
+    // Unmap
+    glUnmapBuffer(GL_SHADER_STORAGE_BUFFER); // sortIdxSSBO
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, cellKeySSBO);
+    glUnmapBuffer(GL_SHADER_STORAGE_BUFFER); // cellKeySSBO
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
+}
+
+// Simple helper (currently just returns param_boxHalf; extend if you need fitted logic)
+Vec3 SPHFluidGPU::ComputeAABBFittedHalf() const {
+    return param_boxHalf;
+}
 GLuint SPHFluidGPU::LoadComputeShader(const char* filePath) {
     std::ifstream file(filePath);
-    if (!file.is_open()) { Debug::FatalError("Failed to open compute shader file", __FILE__, __LINE__); }
-    std::stringstream ss; ss << file.rdbuf();
-    std::string sourceStr = ss.str();
-    const char* source = sourceStr.c_str();
+    if (!file.is_open()) Debug::FatalError(std::string("Failed to open compute shader: ") + filePath, __FILE__, __LINE__);
+    std::stringstream ss; ss << file.rdbuf(); std::string src = ss.str();
+    const char* source = src.c_str();
 
-    GLuint shader = glCreateShader(GL_COMPUTE_SHADER);
-    glShaderSource(shader, 1, &source, nullptr);
-    glCompileShader(shader);
-    GLint ok = 0; glGetShaderiv(shader, GL_COMPILE_STATUS, &ok);
+    GLuint sh = glCreateShader(GL_COMPUTE_SHADER);
+    glShaderSource(sh, 1, &source, nullptr);
+    glCompileShader(sh);
+    GLint ok = 0; glGetShaderiv(sh, GL_COMPILE_STATUS, &ok);
     if (!ok) {
-        GLint maxLen = 0; glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &maxLen);
-        std::string log(maxLen, ' '); glGetShaderInfoLog(shader, maxLen, &maxLen, &log[0]);
-        glDeleteShader(shader);
-        Debug::FatalError("Compute shader compilation failed:\n" + log, __FILE__, __LINE__);
+        GLint len = 0; glGetShaderiv(sh, GL_INFO_LOG_LENGTH, &len);
+        std::string log(len, ' '); glGetShaderInfoLog(sh, len, &len, log.data());
+        glDeleteShader(sh);
+        Debug::FatalError("Compute compile failed:\n" + log, __FILE__, __LINE__);
     }
     GLuint prog = glCreateProgram();
-    glAttachShader(prog, shader);
+    glAttachShader(prog, sh);
     glLinkProgram(prog);
-    glDeleteShader(shader);
-    GLint linked = 0; glGetProgramiv(prog, GL_LINK_STATUS, &linked);
-    if (!linked) {
-        GLint maxLen = 0; glGetProgramiv(prog, GL_INFO_LOG_LENGTH, &maxLen);
-        std::string log(maxLen, ' '); glGetProgramInfoLog(prog, maxLen, &maxLen, &log[0]);
+    glDeleteShader(sh);
+    glGetProgramiv(prog, GL_LINK_STATUS, &ok);
+    if (!ok) {
+        GLint len = 0; glGetProgramiv(prog, GL_INFO_LOG_LENGTH, &len);
+        std::string log(len, ' '); glGetProgramInfoLog(prog, len, &len, log.data());
         glDeleteProgram(prog);
-        Debug::FatalError("Compute shader link failed:\n" + log, __FILE__, __LINE__);
+        Debug::FatalError("Compute link failed:\n" + log, __FILE__, __LINE__);
     }
     return prog;
-}
-
-void SPHFluidGPU::BuildGhostGrids() {
-    float spacing = param_h * 0.85f;
-    int cells = int(ceil((2.0f * box) / spacing)) + 1;
-
-    ghostXNeg.init(-box, -box, spacing, cells, cells);
-    ghostXPos.init(-box, -box, spacing, cells, cells);
-    ghostYNeg.init(-box, -box, spacing, cells, cells);
-    ghostYPos.init(-box, -box, spacing, cells, cells);
-    ghostZNeg.init(-box, -box, spacing, cells, cells);
-    ghostZPos.init(-box, -box, spacing, cells, cells);
-
-    for (size_t i = 0; i < particles.size(); ++i) {
-        const SPHParticle& p = particles[i];
-        if (!p.isGhost) continue;
-        if (fabs(p.pos.x + box) < 1e-4f) ghostXNeg.addGhost(p.pos.y, p.pos.z, i);
-        if (fabs(p.pos.x - box) < 1e-4f) ghostXPos.addGhost(p.pos.y, p.pos.z, i);
-        if (fabs(p.pos.y + box) < 1e-4f) ghostYNeg.addGhost(p.pos.x, p.pos.z, i);
-        if (fabs(p.pos.y - box) < 1e-4f) ghostYPos.addGhost(p.pos.x, p.pos.z, i);
-        if (fabs(p.pos.z + box) < 1e-4f) ghostZNeg.addGhost(p.pos.x, p.pos.y, i);
-        if (fabs(p.pos.z - box) < 1e-4f) ghostZPos.addGhost(p.pos.x, p.pos.y, i);
-    }
-}
-
-// --- kept for completeness (not used when param_enableGhosts=false)
-void SPHFluidGPU::ActivateClosestGhost(float, float, float) {}
-void SPHFluidGPU::UpdateGhostParticlesDynamic(float) {}
-void SPHFluidGPU::UploadGhostActivityToGPU() {
-    glBindBuffer(GL_SHADER_STORAGE_BUFFER, ssbo);
-    glBufferSubData(GL_SHADER_STORAGE_BUFFER, 0, sizeof(SPHParticle) * particles.size(), particles.data());
-    glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
 }

--- a/ComponentFramework/SPHFluid3D.cpp
+++ b/ComponentFramework/SPHFluid3D.cpp
@@ -5,6 +5,35 @@
 #include <random>
 #include <vector>
 #include <iostream>
+#include <cmath>
+#include <SDL_stdinc.h>
+
+
+
+static void MakeRotationMat3XYZ(float rxDeg, float ryDeg, float rzDeg, float outM[9]) {
+    const float rx = rxDeg * float(M_PI / 180.0);
+    const float ry = ryDeg * float(M_PI / 180.0);
+    const float rz = rzDeg * float(M_PI / 180.0);
+    const float cx = cosf(rx), sx = sinf(rx);
+    const float cy = cosf(ry), sy = sinf(ry);
+    const float cz = cosf(rz), sz = sinf(rz);
+    // Column-major mat3 of Rz*Ry*Rx
+    const float Rz[9] = { cz, sz, 0, -sz, cz, 0, 0, 0, 1 };
+    const float Ry[9] = { cy, 0, -sy, 0, 1, 0, sy, 0, cy };
+    const float Rx[9] = { 1, 0, 0, 0, cx, sx, 0, -sx, cx };
+    auto mul3 = [](const float A[9], const float B[9], float C[9]) {
+        // C = A*B (column-major)
+        for (int c = 0; c < 3; c++) {
+            for (int r = 0; r < 3; r++) {
+                C[c * 3 + r] = A[0 * 3 + r] * B[c * 3 + 0] + A[1 * 3 + r] * B[c * 3 + 1] + A[2 * 3 + r] * B[c * 3 + 2];
+            }
+        }
+        };
+    float Rzy[9]; mul3(Rz, Ry, Rzy);
+    mul3(Rzy, Rx, outM);
+}
+
+
 
 SPHFluidGPU::SPHFluidGPU(size_t numParticles_)
     : numParticles(numParticles_), fluidVBO(0), vboPtr(nullptr), numFluids(0)
@@ -12,13 +41,16 @@ SPHFluidGPU::SPHFluidGPU(size_t numParticles_)
     clearGridShader = LoadComputeShader("shaders/ClearGrid.comp");
     buildGridShader = LoadComputeShader("shaders/BuildGrid.comp");
     sphGridShader = LoadComputeShader("shaders/SPHFluid.comp");
-    radixSortShader = LoadComputeShader("shaders/RadixSort.comp"); 
+    radixSortShader = LoadComputeShader("shaders/RadixSort.comp");
+    obbConstraintShader = LoadComputeShader("shaders/OBBConstraints.comp"); // NEW
+
+    InitializeGridAndBuffers();
+
 
     InitializeParticles();
     InitializeFluidVBO();
-    InitializeGridAndBuffers();
     UploadDataToGPU();
-    InitializeSortBuffers(); 
+    InitializeSortBuffers();
 }
 
 SPHFluidGPU::~SPHFluidGPU() {
@@ -30,62 +62,62 @@ SPHFluidGPU::~SPHFluidGPU() {
     glDeleteBuffers(1, &cellHeadSSBO);
     glDeleteBuffers(1, &particleNextSSBO);
     glDeleteBuffers(1, &particleCellSSBO);
-    glDeleteBuffers(1, &cellKeySSBO);   
-    glDeleteBuffers(1, &sortIdxSSBO);   
-    glDeleteBuffers(1, &sortTmpSSBO);  
+    glDeleteBuffers(1, &cellKeySSBO);
+    glDeleteBuffers(1, &sortIdxSSBO);
+    glDeleteBuffers(1, &sortTmpSSBO);
     glDeleteProgram(clearGridShader);
     glDeleteProgram(buildGridShader);
     glDeleteProgram(sphGridShader);
-    glDeleteProgram(radixSortShader);  
+    glDeleteProgram(radixSortShader);
 }
 
 void SPHFluidGPU::InitializeParticles() {
-    float h = 0.28f;
+
+    this->box = std::max(param_boxHalf.x, std::max(param_boxHalf.y, param_boxHalf.z));
+
+    float h = param_h;                      // use current smoothing length
     float spacing = h * 0.85f;
     float box = this->box;
 
     particles.clear();
     int count = 0;
 
-    // Set the fluid fill height as a fraction of the box (e.g., 60% full)
     float fillFraction = 0.4f;
     float fluidHeight = (2.0f * box) * fillFraction;
-
-    // Calculate number of layers and side count
     int fluidLayersY = int(fluidHeight / spacing);
     int fluidSide = int((box * 1.7f) / spacing);
 
     std::default_random_engine rng(static_cast<unsigned>(time(nullptr)));
-    std::uniform_real_distribution<float> jitter(-spacing * 0.2f, spacing * 0.2f);
+    std::uniform_real_distribution<float> jitterDist(-spacing * param_jitterAmp,
+        +spacing * param_jitterAmp);
+
+    auto j = [&]() -> float { return param_useJitter ? jitterDist(rng) : 0.0f; };
 
     // Fill a block at the bottom of the box
-    for (int x = 0; x < fluidSide; ++x) {
-        for (int y = 0; y < fluidLayersY; ++y) {
-            for (int z = 0; z < fluidSide; ++z) {
-                if (count >= numParticles) break;
+    for (int x = 0; x < fluidSide && count < numParticles; ++x) {
+        for (int y = 0; y < fluidLayersY && count < numParticles; ++y) {
+            for (int z = 0; z < fluidSide && count < numParticles; ++z) {
                 SPHParticle p;
                 p.pos = Vec4(
-                    -box * 0.7f + x * spacing + jitter(rng),
-                    -box + spacing + y * spacing + jitter(rng), // Start at bottom
-                    -box * 0.7f + z * spacing + jitter(rng),
+                    -box * 0.7f + x * spacing + j(),
+                    -box + spacing + y * spacing + j(), // Start at bottom
+                    -box * 0.7f + z * spacing + j(),
                     0.0f
                 );
-        p.vel = Vec4(0, 0, 0, 0);
-        p.acc = Vec4(0, 0, 0, 0);
-        p.density = 0.0f;
-        p.pressure = 0.0f;
-        p.isGhost = 0;
-        p.isActive = 0;
-        p.pad0 = 0.0f;
-        particles.push_back(p);
-        ++count;
+                p.vel = Vec4(0, 0, 0, 0);
+                p.acc = Vec4(0, 0, 0, 0);
+                p.density = 0.0f;
+                p.pressure = 0.0f;
+                p.isGhost = 0;
+                p.isActive = 0;
+                p.pad0 = 0.0f;
+                particles.push_back(p);
+                ++count;
             }
-            if (count >= numParticles) break;
         }
-        if (count >= numParticles) break;
     }
 
-    // Add ghost particles on all boundaries 
+    // Ghosts on all boundaries (use spacing from param_h)
     auto add_ghost = [&](float x, float y, float z) {
         SPHParticle p;
         p.pos = Vec4(x, y, z, 0.0f);
@@ -99,23 +131,14 @@ void SPHFluidGPU::InitializeParticles() {
         particles.push_back(p);
         };
     for (float y = -box; y <= box; y += spacing)
-        for (float z = -box; z <= box; z += spacing) {
-            add_ghost(-box, y, z);
-            add_ghost(box, y, z);
-        }
+        for (float z = -box; z <= box; z += spacing) { add_ghost(-box, y, z); add_ghost(box, y, z); }
     for (float x = -box; x <= box; x += spacing)
-        for (float z = -box; z <= box; z += spacing) {
-            add_ghost(x, -box, z);
-            add_ghost(x, box, z);
-        }
+        for (float z = -box; z <= box; z += spacing) { add_ghost(x, -box, z); add_ghost(x, box, z); }
     for (float x = -box; x <= box; x += spacing)
-        for (float y = -box; y <= box; y += spacing) {
-            add_ghost(x, y, -box);
-            add_ghost(x, y, box);
-        }
+        for (float y = -box; y <= box; y += spacing) { add_ghost(x, y, -box); add_ghost(x, y, box); }
 
     std::cout << "Fluid particles: " << count << ", ghosts: " << (particles.size() - count) << std::endl;
-    BuildGhostGrids(); 
+    BuildGhostGrids();
 }
 
 void SPHFluidGPU::InitializeFluidVBO() {
@@ -157,11 +180,29 @@ void SPHFluidGPU::UpdateFluidVBOFromGPU() {
     glUnmapBuffer(GL_SHADER_STORAGE_BUFFER);
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
 }
+
+
 void SPHFluidGPU::InitializeGridAndBuffers() {
-    float h = 0.28f;
+    float h = param_h;
     cellSize = h;
-    gridSizeX = gridSizeY = gridSizeZ = int(ceil((2.0f * box) / cellSize));
+
+    // Grid dimensions around current box extents
+    Vec3 half = param_boxHalf;
+    gridSizeX = int(ceil((2.0f * half.x) / cellSize));
+    gridSizeY = int(ceil((2.0f * half.y) / cellSize));
+    gridSizeZ = int(ceil((2.0f * half.z) / cellSize));
+    gridSizeX = std::max(1, gridSizeX);
+    gridSizeY = std::max(1, gridSizeY);
+    gridSizeZ = std::max(1, gridSizeZ);
     numCells = gridSizeX * gridSizeY * gridSizeZ;
+
+    // Legacy fallback for other code using 'box'
+    box = std::max(half.x, std::max(half.y, half.z));
+
+    // SSBOs
+    if (cellHeadSSBO) glDeleteBuffers(1, &cellHeadSSBO);
+    if (particleNextSSBO) glDeleteBuffers(1, &particleNextSSBO);
+    if (particleCellSSBO) glDeleteBuffers(1, &particleCellSSBO);
 
     glGenBuffers(1, &cellHeadSSBO);
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, cellHeadSSBO);
@@ -181,6 +222,12 @@ void SPHFluidGPU::InitializeGridAndBuffers() {
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 2, particleNextSSBO);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 3, particleCellSSBO);
 }
+
+
+void SPHFluidGPU::RecreateGridForBox() {
+    InitializeGridAndBuffers();
+}
+
 
 // --- NEW: Initialize sorting buffers
 void SPHFluidGPU::InitializeSortBuffers() {
@@ -217,45 +264,45 @@ void SPHFluidGPU::RadixSortByCell() {
         glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
     }
 }
-void SPHFluidGPU::ActivateClosestGhost(float x, float y, float z) {  
+
+void SPHFluidGPU::ActivateClosestGhost(float x, float y, float z) {
     // Determine which face is closest  
-    float dists[6] = { fabs(x + box), fabs(x - box), fabs(y + box), fabs(y - box), fabs(z + box), fabs(z - box) };  
-    int face = int(std::min_element(dists, dists + 6) - dists);  
+    float dists[6] = { fabs(x + box), fabs(x - box), fabs(y + box), fabs(y - box), fabs(z + box), fabs(z - box) };
+    int face = int(std::min_element(dists, dists + 6) - dists);
 
-    const std::vector<size_t>* candidates = nullptr;  
-    float a = 0, b = 0;  
-    switch (face) {  
-    case 0: candidates = &ghostXNeg.getCell(y, z); a = y; b = z; break;  
-    case 1: candidates = &ghostXPos.getCell(y, z); a = y; b = z; break;  
-    case 2: candidates = &ghostYNeg.getCell(x, z); a = x; b = z; break;  
-    case 3: candidates = &ghostYPos.getCell(x, z); a = x; b = z; break;  
-    case 4: candidates = &ghostZNeg.getCell(x, y); a = x; b = y; break;  
-    case 5: candidates = &ghostZPos.getCell(x, y); a = x; b = y; break;  
-    }  
+    const std::vector<size_t>* candidates = nullptr;
+    float a = 0, b = 0;
+    switch (face) {
+    case 0: candidates = &ghostXNeg.getCell(y, z); a = y; b = z; break;
+    case 1: candidates = &ghostXPos.getCell(y, z); a = y; b = z; break;
+    case 2: candidates = &ghostYNeg.getCell(x, z); a = x; b = z; break;
+    case 3: candidates = &ghostYPos.getCell(x, z); a = x; b = z; break;
+    case 4: candidates = &ghostZNeg.getCell(x, y); a = x; b = y; break;
+    case 5: candidates = &ghostZPos.getCell(x, y); a = x; b = y; break;
+    }
 
-    // Ensure candidates is not null before dereferencing  
-    if (candidates == nullptr || candidates->empty()) {  
-        return; // No valid candidates, exit early  
-    }  
+    if (candidates == nullptr || candidates->empty()) {
+        return;
+    }
 
-    float minDist2 = std::numeric_limits<float>::max();  
-    size_t minIdx = size_t(-1);  
-    for (size_t idx : *candidates) {  
-        const SPHParticle& ghost = particles[idx];  
-        float dx = ghost.pos.x - x;  
-        float dy = ghost.pos.y - y;  
-        float dz = ghost.pos.z - z;  
-        float dist2 = dx * dx + dy * dy + dz * dz;  
-        if (dist2 < minDist2) {  
-            minDist2 = dist2;  
-            minIdx = idx;  
-        }  
-    }  
-    if (minIdx != size_t(-1)) {  
-        particles[minIdx].isActive = 1;  
-    }  
-    
+    float minDist2 = std::numeric_limits<float>::max();
+    size_t minIdx = size_t(-1);
+    for (size_t idx : *candidates) {
+        const SPHParticle& ghost = particles[idx];
+        float dx = ghost.pos.x - x;
+        float dy = ghost.pos.y - y;
+        float dz = ghost.pos.z - z;
+        float dist2 = dx * dx + dy * dy + dz * dz;
+        if (dist2 < minDist2) {
+            minDist2 = dist2;
+            minIdx = idx;
+        }
+    }
+    if (minIdx != size_t(-1)) {
+        particles[minIdx].isActive = 1;
+    }
 }
+
 void SPHFluidGPU::UpdateGhostParticlesDynamic(float h) {
     // Deactivate all ghosts
     for (auto& p : particles) {
@@ -286,17 +333,20 @@ void SPHFluidGPU::UploadGhostActivityToGPU() {
         sizeof(SPHParticle) * particles.size(), particles.data());
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
 }
-// -- Upload full particle buffer to GPU
+
 void SPHFluidGPU::UploadDataToGPU() {
     glGenBuffers(1, &ssbo);
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, ssbo);
-    glBufferData(GL_SHADER_STORAGE_BUFFER, sizeof(SPHParticle) * particles.size(), particles.data(), GL_DYNAMIC_COPY);
+    const GLsizeiptr sz = sizeof(SPHParticle) * particles.size();
+    glBufferData(GL_SHADER_STORAGE_BUFFER, sz, particles.data(), GL_DYNAMIC_COPY);
+
+    GLint64 gpuSize = 0;
+    glGetBufferParameteri64v(GL_SHADER_STORAGE_BUFFER, GL_BUFFER_SIZE, &gpuSize);
+    if (gpuSize != sz) std::cerr << "SSBO size mismatch: " << gpuSize << " vs " << sz << "\n";
+
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, ssbo);
-
-    GLenum err = glGetError();
-    if (err != GL_NO_ERROR) std::cout << "OpenGL error after buffer alloc: " << err << std::endl;
-    std::cout << "sizeof(SPHParticle): " << sizeof(SPHParticle) << std::endl;
-
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
+    std::cout << "sizeof(SPHParticle)=" << sizeof(SPHParticle) << " bytes\n"; // should be 80
 }
 
 void SPHFluidGPU::DownloadDataFromGPU() {
@@ -305,58 +355,65 @@ void SPHFluidGPU::DownloadDataFromGPU() {
         (const SPHParticle*)glMapBuffer(GL_SHADER_STORAGE_BUFFER, GL_READ_ONLY);
     if (gpuParticles) {
         memcpy(particles.data(), gpuParticles,
-               sizeof(SPHParticle) * particles.size());
+            sizeof(SPHParticle) * particles.size());
     }
     glUnmapBuffer(GL_SHADER_STORAGE_BUFFER);
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
 }
 
-
 void SPHFluidGPU::DispatchCompute() {
-    float h = 0.28f;                // Smoothing length (keep as is if your particle spacing is ~0.24)
-    float spacing = h * 0.85f;      // Particle spacing (good)
-    float mass = 1.0f;              // Mass per particle (see note below)
-    float restDensity = 1000.0f;    // Water density in kg/m^3 (or g/cm^3 if using CGS, so 1000.0)
-    float gasConstant = 2000.0f;    // Stiffness (try 2000–3000 for water, higher = less compressible)
-    float viscosity = 3.5f;         // Dynamic viscosity (water: 3.5–10.0 in CGS units)
-    MATH::Vec3 gravity = MATH::Vec3(0, -980.0f, 0); // Gravity in cm/s^2 (earth gravity)
-    float surfaceTension = 0.0728f; // Water surface tension in N/m (0.0728), but 0.07–0.2 is typical for SPH
-    float timeStep = 0.005f;        // 1 ms per st
+    if (param_pause) {
+        return;
+    }
 
-    // Sync CPU copy with latest GPU data so ghost activation uses fresh positions
-    DownloadDataFromGPU();
-    UpdateGhostParticlesDynamic(h);
-    UploadGhostActivityToGPU();
+    // Live parameters
+    float h = param_h;
+    float mass = param_mass;
+    float restDensity = param_restDensity;
+    float gasConstant = param_gasConstant;
+    float viscosity = param_viscosity;
+    MATH::Vec3 gravity = MATH::Vec3(0, param_gravityY, 0);
+    float surfaceTension = param_surfaceTension;
+    float timeStep = param_timeStep;
 
-    // 1. Clear grid
+    // Only do ghost activation if enabled (CPU sync)
+    if (param_enableGhosts) {
+        DownloadDataFromGPU();
+        UpdateGhostParticlesDynamic(h);
+        UploadGhostActivityToGPU();
+    }
+
+    // 1) Clear grid
     glUseProgram(clearGridShader);
     glUniform1i(glGetUniformLocation(clearGridShader, "numCells"), numCells);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, cellHeadSSBO);
     glDispatchCompute((numCells + 255) / 256, 1, 1);
     glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
 
-    // 2. Build grid (write cellKeySSBO, etc)
+    // 2) Build grid (now uses gridMin offset)
     glUseProgram(buildGridShader);
     glUniform3i(glGetUniformLocation(buildGridShader, "gridSize"), gridSizeX, gridSizeY, gridSizeZ);
     glUniform1f(glGetUniformLocation(buildGridShader, "cellSize"), cellSize);
-    glUniform1f(glGetUniformLocation(buildGridShader, "box"), box);
+    const Vec3 gridMin = param_boxCenter - param_boxHalf;
+    glUniform3f(glGetUniformLocation(buildGridShader, "gridMin"), gridMin.x, gridMin.y, gridMin.z);
     glUniform1i(glGetUniformLocation(buildGridShader, "numParticles"), int(particles.size()));
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, ssbo);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, cellHeadSSBO);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 2, particleNextSSBO);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 3, particleCellSSBO);
-    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 4, cellKeySSBO); // <<== NEW
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 4, cellKeySSBO);
     glDispatchCompute((particles.size() + 255) / 256, 1, 1);
     glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
 
-    // 3. Sort indices by cell index!
-    RadixSortByCell();
+    // 3) Sort by cell (optional / unused by SPH kernel)
+    if (param_enableSort) {
+        RadixSortByCell();
+    }
 
-    // 4. SPH step: now neighbor loops can use sorted indices!
+    // 4) SPH step
     glUseProgram(sphGridShader);
     glUniform3i(glGetUniformLocation(sphGridShader, "gridSize"), gridSizeX, gridSizeY, gridSizeZ);
     glUniform1f(glGetUniformLocation(sphGridShader, "cellSize"), cellSize);
-    glUniform1f(glGetUniformLocation(sphGridShader, "box"), box);
     glUniform1i(glGetUniformLocation(sphGridShader, "numParticles"), int(particles.size()));
     glUniform1f(glGetUniformLocation(sphGridShader, "timeStep"), timeStep);
     glUniform1f(glGetUniformLocation(sphGridShader, "h"), h);
@@ -365,21 +422,35 @@ void SPHFluidGPU::DispatchCompute() {
     glUniform1f(glGetUniformLocation(sphGridShader, "gasConstant"), gasConstant);
     glUniform1f(glGetUniformLocation(sphGridShader, "viscosity"), viscosity);
     glUniform3f(glGetUniformLocation(sphGridShader, "gravity"), gravity.x, gravity.y, gravity.z);
-    glUniform1f(glGetUniformLocation(sphGridShader, "surfaceTension"), 2.0f); // Tune as needed
+    glUniform1f(glGetUniformLocation(sphGridShader, "surfaceTension"), surfaceTension);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, ssbo);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, cellHeadSSBO);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 2, particleNextSSBO);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 3, particleCellSSBO);
-    // Optionally pass sorted indices to your SPH kernel here
+
     glDispatchCompute((particles.size() + 255) / 256, 1, 1);
     glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
+
+    // 5) OBB boundary constraints (fast)
+    {
+        glUseProgram(obbConstraintShader);
+        float R[9]; MakeRotationMat3XYZ(param_boxEulerDeg.x, param_boxEulerDeg.y, param_boxEulerDeg.z, R);
+        glUniformMatrix3fv(glGetUniformLocation(obbConstraintShader, "uBoxRot"), 1, GL_FALSE, R);
+        glUniform3f(glGetUniformLocation(obbConstraintShader, "uBoxCenter"), param_boxCenter.x, param_boxCenter.y, param_boxCenter.z);
+        glUniform3f(glGetUniformLocation(obbConstraintShader, "uBoxHalf"), param_boxHalf.x, param_boxHalf.y, param_boxHalf.z);
+        glUniform1f(glGetUniformLocation(obbConstraintShader, "uRestitution"), param_wallRestitution);
+        glUniform1f(glGetUniformLocation(obbConstraintShader, "uFriction"), param_wallFriction);
+        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, ssbo);
+        glDispatchCompute((particles.size() + 255) / 256, 1, 1);
+        glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
+    }
 
     glUseProgram(0);
 }
 
 GLuint SPHFluidGPU::GetFluidVBO() const { return fluidVBO; }
 size_t SPHFluidGPU::GetNumFluids() const { return numFluids; }
-// Standard shader loading
+
 GLuint SPHFluidGPU::LoadComputeShader(const char* filePath) {
     std::ifstream file(filePath);
     if (!file.is_open()) {
@@ -425,7 +496,7 @@ GLuint SPHFluidGPU::LoadComputeShader(const char* filePath) {
 }
 
 void SPHFluidGPU::BuildGhostGrids() {
-    float spacing = 0.28f * 0.85f;
+    float spacing = param_h * 0.85f;  // use current h
     int cells = int(ceil((2.0f * box) / spacing)) + 1;
 
     // X faces: grid in (y, z)
@@ -448,4 +519,59 @@ void SPHFluidGPU::BuildGhostGrids() {
         if (fabs(p.pos.z + box) < 1e-4f) ghostZNeg.addGhost(p.pos.x, p.pos.y, i);
         if (fabs(p.pos.z - box) < 1e-4f) ghostZPos.addGhost(p.pos.x, p.pos.y, i);
     }
+}
+
+// NEW: sine-wave velocity kick
+void SPHFluidGPU::ApplyWaveImpulse(float amplitude, float wavelength, float phase, const Vec3& dir,
+    float yMin, float yMax)
+{
+    if (amplitude == 0.0f || wavelength <= 1e-6f) return;
+
+    // Bring CPU side in sync, modify CPU buffer, push back to GPU.
+    DownloadDataFromGPU();
+
+    const float k = 2.0f * float(M_PI) / wavelength;
+    Vec3 nDir = dir;
+    float len = sqrtf(nDir.x * nDir.x + nDir.y * nDir.y + nDir.z * nDir.z);
+    if (len > 0.0f) { nDir /= len; }
+    else { nDir = Vec3(0, 1, 0); }
+
+    for (auto& p : particles) {
+        if (p.isGhost) continue;
+        if (p.pos.y < yMin || p.pos.y > yMax) continue;
+
+        // Phase using x+z to create ripples across the surface
+        float theta = k * (p.pos.x + p.pos.z) + phase;
+        float kick = amplitude * sinf(theta);
+
+        p.vel.x += nDir.x * kick;
+        p.vel.y += nDir.y * kick;
+        p.vel.z += nDir.z * kick;
+    }
+
+    // Upload updated particle velocities
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, ssbo);
+    glBufferSubData(GL_SHADER_STORAGE_BUFFER, 0, sizeof(SPHParticle) * particles.size(), particles.data());
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
+}
+
+// NEW: full reset of particle set and buffers
+void SPHFluidGPU::ResetSimulation()
+{
+    // Destroy GPU buffers we own
+    if (fluidVBO) { glBindBuffer(GL_ARRAY_BUFFER, 0); glDeleteBuffers(1, &fluidVBO); fluidVBO = 0; vboPtr = nullptr; }
+    if (ssbo) { glDeleteBuffers(1, &ssbo); ssbo = 0; }
+    if (cellHeadSSBO) { glDeleteBuffers(1, &cellHeadSSBO); cellHeadSSBO = 0; }
+    if (particleNextSSBO) { glDeleteBuffers(1, &particleNextSSBO); particleNextSSBO = 0; }
+    if (particleCellSSBO) { glDeleteBuffers(1, &particleCellSSBO); particleCellSSBO = 0; }
+    if (cellKeySSBO) { glDeleteBuffers(1, &cellKeySSBO); cellKeySSBO = 0; }
+    if (sortIdxSSBO) { glDeleteBuffers(1, &sortIdxSSBO); sortIdxSSBO = 0; }
+    if (sortTmpSSBO) { glDeleteBuffers(1, &sortTmpSSBO); sortTmpSSBO = 0; }
+
+    // Rebuild in the correct order: box/grid first, then particles
+    InitializeGridAndBuffers();
+    InitializeParticles();
+    InitializeSortBuffers();
+    UploadDataToGPU();
+    InitializeFluidVBO();
 }

--- a/ComponentFramework/SPHFluid3D.cpp
+++ b/ComponentFramework/SPHFluid3D.cpp
@@ -300,7 +300,19 @@ void SPHFluidGPU::UploadDataToGPU() {
 
 }
 
-// ... (DownloadDataFromGPU & VBO update same as before)
+void SPHFluidGPU::DownloadDataFromGPU() {
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, ssbo);
+    const SPHParticle* gpuParticles =
+        (const SPHParticle*)glMapBuffer(GL_SHADER_STORAGE_BUFFER, GL_READ_ONLY);
+    if (gpuParticles) {
+        memcpy(particles.data(), gpuParticles,
+               sizeof(SPHParticle) * particles.size());
+    }
+    glUnmapBuffer(GL_SHADER_STORAGE_BUFFER);
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
+}
+
+// ... (VBO update same as before)
 
 void SPHFluidGPU::DispatchCompute() {
     float h = 0.28f;
@@ -313,6 +325,8 @@ void SPHFluidGPU::DispatchCompute() {
     float surfaceTension = 0.5f;
     float timeStep = 0.002f;
 
+    // Sync CPU copy with latest GPU data so ghost activation uses fresh positions
+    DownloadDataFromGPU();
     UpdateGhostParticlesDynamic(h);
     UploadGhostActivityToGPU();
 

--- a/ComponentFramework/SPHFluid3D.cpp
+++ b/ComponentFramework/SPHFluid3D.cpp
@@ -70,14 +70,15 @@ void SPHFluidGPU::InitializeParticles() {
                     -box * 0.7f + z * spacing + jitter(rng),
                     0.0f
                 );
-                p.vel = Vec4(0, 0, 0, 0);
-                p.acc = Vec4(0, 0, 0, 0);
-                p.density = 0.0f;
-                p.pressure = 0.0f;
-                p.isGhost = 0;
-                p.pad0 = 0.0f;
-                particles.push_back(p);
-                ++count;
+        p.vel = Vec4(0, 0, 0, 0);
+        p.acc = Vec4(0, 0, 0, 0);
+        p.density = 0.0f;
+        p.pressure = 0.0f;
+        p.isGhost = 0;
+        p.isActive = 0;
+        p.pad0 = 0.0f;
+        particles.push_back(p);
+        ++count;
             }
             if (count >= numParticles) break;
         }
@@ -93,6 +94,7 @@ void SPHFluidGPU::InitializeParticles() {
         p.density = 0.0f;
         p.pressure = 0.0f;
         p.isGhost = 1;
+        p.isActive = 0;
         p.pad0 = 0.0f;
         particles.push_back(p);
         };
@@ -278,6 +280,13 @@ void SPHFluidGPU::UpdateGhostParticlesDynamic(float h) {
         if (fluid.pos.z > box - h)  ActivateClosestGhost(fluid.pos.x, fluid.pos.y, box);
     }
 }
+
+void SPHFluidGPU::UploadGhostActivityToGPU() {
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, ssbo);
+    glBufferSubData(GL_SHADER_STORAGE_BUFFER, 0,
+        sizeof(SPHParticle) * particles.size(), particles.data());
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
+}
 // -- Upload full particle buffer to GPU
 void SPHFluidGPU::UploadDataToGPU() {
     glGenBuffers(1, &ssbo);
@@ -303,7 +312,9 @@ void SPHFluidGPU::DispatchCompute() {
     MATH::Vec3 gravity = MATH::Vec3(0, -980.0f, 0);
     float surfaceTension = 0.5f;
     float timeStep = 0.002f;
-   
+
+    UpdateGhostParticlesDynamic(h);
+    UploadGhostActivityToGPU();
 
     // 1. Clear grid
     glUseProgram(clearGridShader);
@@ -317,6 +328,7 @@ void SPHFluidGPU::DispatchCompute() {
     glUniform3i(glGetUniformLocation(buildGridShader, "gridSize"), gridSizeX, gridSizeY, gridSizeZ);
     glUniform1f(glGetUniformLocation(buildGridShader, "cellSize"), cellSize);
     glUniform1f(glGetUniformLocation(buildGridShader, "box"), box);
+    glUniform1i(glGetUniformLocation(buildGridShader, "numParticles"), int(particles.size()));
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, ssbo);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, cellHeadSSBO);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 2, particleNextSSBO);
@@ -333,6 +345,7 @@ void SPHFluidGPU::DispatchCompute() {
     glUniform3i(glGetUniformLocation(sphGridShader, "gridSize"), gridSizeX, gridSizeY, gridSizeZ);
     glUniform1f(glGetUniformLocation(sphGridShader, "cellSize"), cellSize);
     glUniform1f(glGetUniformLocation(sphGridShader, "box"), box);
+    glUniform1i(glGetUniformLocation(sphGridShader, "numParticles"), int(particles.size()));
     glUniform1f(glGetUniformLocation(sphGridShader, "timeStep"), timeStep);
     glUniform1f(glGetUniformLocation(sphGridShader, "h"), h);
     glUniform1f(glGetUniformLocation(sphGridShader, "mass"), mass);

--- a/ComponentFramework/SPHFluid3D.cpp
+++ b/ComponentFramework/SPHFluid3D.cpp
@@ -321,7 +321,7 @@ void SPHFluidGPU::DispatchCompute() {
     float viscosity = 3.5f;         // Dynamic viscosity (water: 3.5–10.0 in CGS units)
     MATH::Vec3 gravity = MATH::Vec3(0, -980.0f, 0); // Gravity in cm/s^2 (earth gravity)
     float surfaceTension = 0.0728f; // Water surface tension in N/m (0.0728), but 0.07–0.2 is typical for SPH
-    float timeStep = 0.001f;        // 1 ms per st
+    float timeStep = 0.005f;        // 1 ms per st
 
     // Sync CPU copy with latest GPU data so ghost activation uses fresh positions
     DownloadDataFromGPU();

--- a/ComponentFramework/SPHFluid3D.cpp
+++ b/ComponentFramework/SPHFluid3D.cpp
@@ -7,41 +7,26 @@
 #include <iostream>
 #include <cmath>
 #include <SDL_stdinc.h>
+#include <algorithm>
 
+static void Mul3x3(const float A[9], const float B[9], float C[9]) {
+    for (int c = 0; c < 3; c++)
+        for (int r = 0; r < 3; r++)
+            C[c * 3 + r] = A[0 * 3 + r] * B[c * 3 + 0] + A[1 * 3 + r] * B[c * 3 + 1] + A[2 * 3 + r] * B[c * 3 + 2];
+}
 
-
-static void MakeRotationMat3XYZ(float rxDeg, float ryDeg, float rzDeg, float outM[9]) {
+void SPHFluid3D::MakeRotationMat3XYZ(float rxDeg, float ryDeg, float rzDeg, float outM[9]) {
     const float rx = rxDeg * float(M_PI / 180.0);
     const float ry = ryDeg * float(M_PI / 180.0);
     const float rz = rzDeg * float(M_PI / 180.0);
     const float cx = cosf(rx), sx = sinf(rx);
     const float cy = cosf(ry), sy = sinf(ry);
     const float cz = cosf(rz), sz = sinf(rz);
-    // Column-major mat3 of Rz*Ry*Rx
     const float Rz[9] = { cz, sz, 0, -sz, cz, 0, 0, 0, 1 };
     const float Ry[9] = { cy, 0, -sy, 0, 1, 0, sy, 0, cy };
     const float Rx[9] = { 1, 0, 0, 0, cx, sx, 0, -sx, cx };
-    auto mul3 = [](const float A[9], const float B[9], float C[9]) {
-        // C = A*B (column-major)
-        for (int c = 0; c < 3; c++) {
-            for (int r = 0; r < 3; r++) {
-                C[c * 3 + r] = A[0 * 3 + r] * B[c * 3 + 0] + A[1 * 3 + r] * B[c * 3 + 1] + A[2 * 3 + r] * B[c * 3 + 2];
-            }
-        }
-        };
-    float Rzy[9]; mul3(Rz, Ry, Rzy);
-    mul3(Rzy, Rx, outM);
-}
-
-MATH::Vec3 SPHFluidGPU::ComputeAABBFittedHalf() const {
-    float R[9];
-    MakeRotationMat3XYZ(param_boxEulerDeg.x, param_boxEulerDeg.y, param_boxEulerDeg.z, R);
-    const Vec3 H = param_boxHalf;
-    // Column-major 3x3: x' = R0*x + R3*y + R6*z, etc.
-    const float ax = std::fabs(R[0]) * H.x + std::fabs(R[3]) * H.y + std::fabs(R[6]) * H.z;
-    const float ay = std::fabs(R[1]) * H.x + std::fabs(R[4]) * H.y + std::fabs(R[7]) * H.z;
-    const float az = std::fabs(R[2]) * H.x + std::fabs(R[5]) * H.y + std::fabs(R[8]) * H.z;
-    return Vec3(ax, ay, az);
+    float Rzy[9]; Mul3x3(Rz, Ry, Rzy);
+    Mul3x3(Rzy, Rx, outM);
 }
 
 SPHFluidGPU::SPHFluidGPU(size_t numParticles_)
@@ -52,24 +37,28 @@ SPHFluidGPU::SPHFluidGPU(size_t numParticles_)
     sphGridShader = LoadComputeShader("shaders/SPHFluid.comp");
     radixSortShader = LoadComputeShader("shaders/RadixSort.comp");
     obbConstraintShader = LoadComputeShader("shaders/OBBConstraints.comp");
+    waveImpulseShader = LoadComputeShader("shaders/WaveImpulse.comp"); // NEW
 
     // 1) Build particles (also sets 'box')
     InitializeParticles();
 
     // 2) Now size grid/aux SSBOs using the actual particle count
     InitializeGridAndBuffers();
+    InitializeSortBuffers();
 
     // 3) GPU resources
     UploadDataToGPU();
-    InitializeSortBuffers();
     InitializeFluidVBO();
+
+    // Cache OBB rotation once
+    cachedBoxCenter = param_boxCenter;
+    cachedBoxHalf = param_boxHalf;
+    cachedBoxEuler = param_boxEulerDeg;
+    MakeRotationMat3XYZ(cachedBoxEuler.x, cachedBoxEuler.y, cachedBoxEuler.z, cachedRot3x3);
 }
 
 SPHFluidGPU::~SPHFluidGPU() {
-    if (fluidVBO) {
-        glBindBuffer(GL_ARRAY_BUFFER, 0);
-        glDeleteBuffers(1, &fluidVBO);
-    }
+    if (fluidVBO) { glBindBuffer(GL_ARRAY_BUFFER, 0); glDeleteBuffers(1, &fluidVBO); }
     glDeleteBuffers(1, &ssbo);
     glDeleteBuffers(1, &cellHeadSSBO);
     glDeleteBuffers(1, &particleNextSSBO);
@@ -81,112 +70,95 @@ SPHFluidGPU::~SPHFluidGPU() {
     glDeleteProgram(buildGridShader);
     glDeleteProgram(sphGridShader);
     glDeleteProgram(radixSortShader);
+    glDeleteProgram(obbConstraintShader);
+    glDeleteProgram(waveImpulseShader);
 }
 
 void SPHFluidGPU::InitializeParticles() {
+    this->box = std::max(param_boxHalf.x, std::max(param_boxHalf.y, param_boxHalf.z));
 
-    // Build in OBB local space [-H,H], then transform to world with R and center
-    float Rm[9];
-    MakeRotationMat3XYZ(param_boxEulerDeg.x, param_boxEulerDeg.y, param_boxEulerDeg.z, Rm);
-    const Vec3 H = param_boxHalf;
-    const Vec3 C = param_boxCenter;
-
-    // Grid spacing from h
     float h = param_h;
     float spacing = h * 0.85f;
-
-    // Mass from spacing
-    param_mass = param_restDensity * spacing * spacing * spacing;
+    float box = this->box;
 
     particles.clear();
     int count = 0;
 
-    // Fill a block at the bottom in local space
-    float fillFraction = 0.4f;
-    float fluidHeight = (2.0f * H.y) * fillFraction;
-    int fluidLayersY = int(fluidHeight / spacing);
-    int fluidSideX = int((2.0f * H.x) / spacing);
-    int fluidSideZ = int((2.0f * H.z) / spacing);
+    const float fillFraction = 0.4f;
+    const float fluidHeight = (2.0f * box) * fillFraction;
+    const int fluidLayersY = int(fluidHeight / spacing);
+    const int fluidSide = int((box * 1.7f) / spacing);
 
     std::default_random_engine rng(static_cast<unsigned>(time(nullptr)));
-    std::uniform_real_distribution<float> jitterDist(-spacing * param_jitterAmp, +spacing * param_jitterAmp);
+    std::uniform_real_distribution<float> jitterDist(-spacing * param_jitterAmp,
+        +spacing * param_jitterAmp);
     auto j = [&]() -> float { return param_useJitter ? jitterDist(rng) : 0.0f; };
 
-    auto xformLocalToWorld = [&](float lx, float ly, float lz) -> Vec3 {
-        // Rotate then translate; R is column-major
-        return Vec3(
-            Rm[0] * lx + Rm[3] * ly + Rm[6] * lz + C.x,
-            Rm[1] * lx + Rm[4] * ly + Rm[7] * lz + C.y,
-            Rm[2] * lx + Rm[5] * ly + Rm[8] * lz + C.z
-        );
-        };
-
-    for (int ix = 0; ix < fluidSideX && count < (int)numParticles; ++ix) {
-        for (int iy = 0; iy < fluidLayersY && count < (int)numParticles; ++iy) {
-            for (int iz = 0; iz < fluidSideZ && count < (int)numParticles; ++iz) {
-                // Local position inside OBB, bottom layer starts at -H.y
-                float lx = -H.x + spacing + ix * spacing + j();
-                float ly = -H.y + spacing + iy * spacing + j();
-                float lz = -H.z + spacing + iz * spacing + j();
-
-                Vec3 w = xformLocalToWorld(lx, ly, lz);
-
+    // Fill a block at the bottom of the box
+    for (int x = 0; x < fluidSide && count < (int)numParticles; ++x) {
+        for (int y = 0; y < fluidLayersY && count < (int)numParticles; ++y) {
+            for (int z = 0; z < fluidSide && count < (int)numParticles; ++z) {
                 SPHParticle p{};
-                p.pos = Vec4(w.x, w.y, w.z, 0.0f);
+                p.pos = Vec4(-box * 0.7f + x * spacing + j(),
+                    -box + spacing + y * spacing + j(),
+                    -box * 0.7f + z * spacing + j(), 0.0f);
                 p.vel = Vec4(0, 0, 0, 0);
                 p.acc = Vec4(0, 0, 0, 0);
-                p.density = 0.0f;
-                p.pressure = 0.0f;
-                p.isGhost = 0;
-                p.isActive = 0;
-                p.pad0 = 0.0f;
+                p.density = 0.0f; p.pressure = 0.0f;
+                p.isGhost = 0; p.isActive = 0;
                 particles.push_back(p);
                 ++count;
             }
         }
     }
 
-    // Legacy ghosts remain axis-aligned around origin/box and don't match OBB.
-    // If you rely on ghosts, prefer keeping param_enableGhosts = false when using OBB.
-    // (Leaving existing ghost build to avoid wider refactor.)
-    this->box = std::max(H.x, std::max(H.y, H.z)); // legacy size used by ghost helpers
-    // Build ghosts and grids for legacy walls
+    // Boundary ghosts
+    auto add_ghost = [&](float x, float y, float z) {
+        SPHParticle p{};
+        p.pos = Vec4(x, y, z, 0); p.vel = Vec4(0, 0, 0, 0); p.acc = Vec4(0, 0, 0, 0);
+        p.density = 0; p.pressure = 0; p.isGhost = 1; p.isActive = 0;
+        particles.push_back(p);
+        };
+    for (float y = -box; y <= box; y += spacing)
+        for (float z = -box; z <= box; z += spacing) { add_ghost(-box, y, z); add_ghost(box, y, z); }
+    for (float x = -box; x <= box; x += spacing)
+        for (float z = -box; z <= box; z += spacing) { add_ghost(x, -box, z); add_ghost(x, box, z); }
+    for (float x = -box; x <= box; x += spacing)
+        for (float y = -box; y <= box; y += spacing) { add_ghost(x, y, -box); add_ghost(x, y, box); }
+
+    std::cout << "Fluid particles: " << count
+        << ", ghosts: " << (particles.size() - count) << std::endl;
+
     BuildGhostGrids();
 }
 
 void SPHFluidGPU::InitializeFluidVBO() {
-    // Count fluids
     numFluids = 0;
-    for (const auto& p : particles)
-        if (p.isGhost == 0) ++numFluids;
+    for (const auto& p : particles) if (p.isGhost == 0) ++numFluids;
 
     if (fluidVBO) glDeleteBuffers(1, &fluidVBO);
-
     glGenBuffers(1, &fluidVBO);
     glBindBuffer(GL_ARRAY_BUFFER, fluidVBO);
     glBufferStorage(GL_ARRAY_BUFFER, sizeof(float) * 4 * numFluids, nullptr,
         GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT);
 
-    vboPtr = (float*)glMapBufferRange(
-        GL_ARRAY_BUFFER, 0, sizeof(float) * 4 * numFluids,
-        GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT
-    );
+    vboPtr = (float*)glMapBufferRange(GL_ARRAY_BUFFER, 0, sizeof(float) * 4 * numFluids,
+        GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT);
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 void SPHFluidGPU::UpdateFluidVBOFromGPU() {
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, ssbo);
     const SPHParticle* gpuParticles = (const SPHParticle*)glMapBuffer(GL_SHADER_STORAGE_BUFFER, GL_READ_ONLY);
-
     if (gpuParticles && vboPtr) {
-        size_t vboIndex = 0;
+        size_t v = 0;
         for (size_t i = 0; i < particles.size(); ++i) {
             if (gpuParticles[i].isGhost == 0) {
-                vboPtr[4 * vboIndex + 0] = gpuParticles[i].pos.x;
-                vboPtr[4 * vboIndex + 1] = gpuParticles[i].pos.y;
-                vboPtr[4 * vboIndex + 2] = gpuParticles[i].pos.z;
-                vboPtr[4 * vboIndex + 3] = 1.0f;
-                ++vboIndex;
+                vboPtr[4 * v + 0] = gpuParticles[i].pos.x;
+                vboPtr[4 * v + 1] = gpuParticles[i].pos.y;
+                vboPtr[4 * v + 2] = gpuParticles[i].pos.z;
+                vboPtr[4 * v + 3] = 1.0f;
+                ++v;
             }
         }
     }
@@ -194,21 +166,17 @@ void SPHFluidGPU::UpdateFluidVBOFromGPU() {
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
 }
 
-
 void SPHFluidGPU::InitializeGridAndBuffers() {
     float h = param_h;
     cellSize = h;
 
-    // Use AABB that bounds the rotated OBB
-    Vec3 halfAA = ComputeAABBFittedHalf();
+    Vec3 half = param_boxHalf;
+    gridSizeX = std::max(1, int(ceil((2.0f * half.x) / cellSize)));
+    gridSizeY = std::max(1, int(ceil((2.0f * half.y) / cellSize)));
+    gridSizeZ = std::max(1, int(ceil((2.0f * half.z) / cellSize)));
+    numCells = gridSizeX * gridSizeY * gridSizeZ;
 
-    gridSizeX = std::max(1, int(std::ceil((2.0f * halfAA.x) / cellSize)));
-    gridSizeY = std::max(1, int(std::ceil((2.0f * halfAA.y) / cellSize)));
-    gridSizeZ = std::max(1, int(std::ceil((2.0f * halfAA.z) / cellSize)));
-    numCells = std::max(1, gridSizeX * gridSizeY * gridSizeZ);
-
-    // Legacy 'box' = max half-extent (AABB) for any code that still uses it
-    box = std::max(halfAA.x, std::max(halfAA.y, halfAA.z));
+    box = std::max(half.x, std::max(half.y, half.z));
 
     const size_t N = std::max<size_t>(particles.size(), 1);
 
@@ -235,13 +203,8 @@ void SPHFluidGPU::InitializeGridAndBuffers() {
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 3, particleCellSSBO);
 }
 
+void SPHFluidGPU::RecreateGridForBox() { InitializeGridAndBuffers(); }
 
-void SPHFluidGPU::RecreateGridForBox() {
-    InitializeGridAndBuffers();
-}
-
-
-// --- NEW: Initialize sorting buffers
 void SPHFluidGPU::InitializeSortBuffers() {
     size_t N = particles.size();
 
@@ -251,8 +214,7 @@ void SPHFluidGPU::InitializeSortBuffers() {
 
     glGenBuffers(1, &sortIdxSSBO);
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, sortIdxSSBO);
-    std::vector<int> idxInit(N);
-    for (size_t i = 0; i < N; ++i) idxInit[i] = int(i);
+    std::vector<int> idxInit(N); for (size_t i = 0; i < N; ++i) idxInit[i] = int(i);
     glBufferData(GL_SHADER_STORAGE_BUFFER, sizeof(int) * N, idxInit.data(), GL_DYNAMIC_COPY);
 
     glGenBuffers(1, &sortTmpSSBO);
@@ -262,88 +224,16 @@ void SPHFluidGPU::InitializeSortBuffers() {
 
 void SPHFluidGPU::RadixSortByCell() {
     size_t N = particles.size();
-    // Assume cellKeys[] has been filled on GPU by BuildGrid.comp
     for (int pass = 0; pass < 8; ++pass) {
         glUseProgram(radixSortShader);
         glUniform1i(glGetUniformLocation(radixSortShader, "N"), int(N));
         glUniform1i(glGetUniformLocation(radixSortShader, "pass"), pass);
-
         glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, cellKeySSBO);
         glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, (pass % 2 == 0) ? sortIdxSSBO : sortTmpSSBO);
         glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 2, (pass % 2 == 0) ? sortTmpSSBO : sortIdxSSBO);
-
         glDispatchCompute((N + 255) / 256, 1, 1);
         glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
     }
-}
-
-void SPHFluidGPU::ActivateClosestGhost(float x, float y, float z) {
-    // Determine which face is closest  
-    float dists[6] = { fabs(x + box), fabs(x - box), fabs(y + box), fabs(y - box), fabs(z + box), fabs(z - box) };
-    int face = int(std::min_element(dists, dists + 6) - dists);
-
-    const std::vector<size_t>* candidates = nullptr;
-    float a = 0, b = 0;
-    switch (face) {
-    case 0: candidates = &ghostXNeg.getCell(y, z); a = y; b = z; break;
-    case 1: candidates = &ghostXPos.getCell(y, z); a = y; b = z; break;
-    case 2: candidates = &ghostYNeg.getCell(x, z); a = x; b = z; break;
-    case 3: candidates = &ghostYPos.getCell(x, z); a = x; b = z; break;
-    case 4: candidates = &ghostZNeg.getCell(x, y); a = x; b = y; break;
-    case 5: candidates = &ghostZPos.getCell(x, y); a = x; b = y; break;
-    }
-
-    if (candidates == nullptr || candidates->empty()) {
-        return;
-    }
-
-    float minDist2 = std::numeric_limits<float>::max();
-    size_t minIdx = size_t(-1);
-    for (size_t idx : *candidates) {
-        const SPHParticle& ghost = particles[idx];
-        float dx = ghost.pos.x - x;
-        float dy = ghost.pos.y - y;
-        float dz = ghost.pos.z - z;
-        float dist2 = dx * dx + dy * dy + dz * dz;
-        if (dist2 < minDist2) {
-            minDist2 = dist2;
-            minIdx = idx;
-        }
-    }
-    if (minIdx != size_t(-1)) {
-        particles[minIdx].isActive = 1;
-    }
-}
-
-void SPHFluidGPU::UpdateGhostParticlesDynamic(float h) {
-    // Deactivate all ghosts
-    for (auto& p : particles) {
-        if (p.isGhost) p.isActive = 0;
-    }
-
-    // For each fluid, check proximity to wall; activate nearest ghost(s) as needed
-    for (const auto& fluid : particles) {
-        if (fluid.isGhost) continue;
-
-        // x-faces
-        if (fluid.pos.x < -box + h) ActivateClosestGhost(-box, fluid.pos.y, fluid.pos.z);
-        if (fluid.pos.x > box - h)  ActivateClosestGhost(box, fluid.pos.y, fluid.pos.z);
-
-        // y-faces
-        if (fluid.pos.y < -box + h) ActivateClosestGhost(fluid.pos.x, -box, fluid.pos.z);
-        if (fluid.pos.y > box - h)  ActivateClosestGhost(fluid.pos.x, box, fluid.pos.z);
-
-        // z-faces
-        if (fluid.pos.z < -box + h) ActivateClosestGhost(fluid.pos.x, fluid.pos.y, -box);
-        if (fluid.pos.z > box - h)  ActivateClosestGhost(fluid.pos.x, fluid.pos.y, box);
-    }
-}
-
-void SPHFluidGPU::UploadGhostActivityToGPU() {
-    glBindBuffer(GL_SHADER_STORAGE_BUFFER, ssbo);
-    glBufferSubData(GL_SHADER_STORAGE_BUFFER, 0,
-        sizeof(SPHParticle) * particles.size(), particles.data());
-    glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
 }
 
 void SPHFluidGPU::UploadDataToGPU() {
@@ -351,44 +241,45 @@ void SPHFluidGPU::UploadDataToGPU() {
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, ssbo);
     const GLsizeiptr sz = sizeof(SPHParticle) * particles.size();
     glBufferData(GL_SHADER_STORAGE_BUFFER, sz, particles.data(), GL_DYNAMIC_COPY);
-
-    GLint64 gpuSize = 0;
-    glGetBufferParameteri64v(GL_SHADER_STORAGE_BUFFER, GL_BUFFER_SIZE, &gpuSize);
-    if (gpuSize != sz) std::cerr << "SSBO size mismatch: " << gpuSize << " vs " << sz << "\n";
-
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, ssbo);
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
-    std::cout << "sizeof(SPHParticle)=" << sizeof(SPHParticle) << " bytes\n"; // should be 80
 }
 
 void SPHFluidGPU::DownloadDataFromGPU() {
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, ssbo);
-    const SPHParticle* gpuParticles =
-        (const SPHParticle*)glMapBuffer(GL_SHADER_STORAGE_BUFFER, GL_READ_ONLY);
+    const SPHParticle* gpuParticles = (const SPHParticle*)glMapBuffer(GL_SHADER_STORAGE_BUFFER, GL_READ_ONLY);
     if (gpuParticles) {
-        memcpy(particles.data(), gpuParticles,
-            sizeof(SPHParticle) * particles.size());
+        memcpy(particles.data(), gpuParticles, sizeof(SPHParticle) * particles.size());
     }
     glUnmapBuffer(GL_SHADER_STORAGE_BUFFER);
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
 }
 
-void SPHFluidGPU::DispatchCompute(float overrideDt) {
+void SPHFluidGPU::UpdateCachedBoxIfNeeded() {
+    if (cachedBoxCenter.x != param_boxCenter.x || cachedBoxCenter.y != param_boxCenter.y || cachedBoxCenter.z != param_boxCenter.z ||
+        cachedBoxHalf.x != param_boxHalf.x || cachedBoxHalf.y != param_boxHalf.y || cachedBoxHalf.z != param_boxHalf.z ||
+        cachedBoxEuler.x != param_boxEulerDeg.x || cachedBoxEuler.y != param_boxEulerDeg.y || cachedBoxEuler.z != param_boxEulerDeg.z) {
+        cachedBoxCenter = param_boxCenter;
+        cachedBoxHalf = param_boxHalf;
+        cachedBoxEuler = param_boxEulerDeg;
+        MakeRotationMat3XYZ(cachedBoxEuler.x, cachedBoxEuler.y, cachedBoxEuler.z, cachedRot3x3);
+    }
+}
+
+void SPHFluidGPU::DispatchCompute() {
     if (param_pause) return;
 
-    // Live parameters
+    // Live params
     float h = param_h;
     float mass = param_mass;
     float restDensity = param_restDensity;
     float gasConstant = param_gasConstant;
     float viscosity = param_viscosity;
-    MATH::Vec3 gravity = MATH::Vec3(0, param_gravityY, 0);
+    Vec3  gravity = Vec3(0, param_gravityY, 0);
     float surfaceTension = param_surfaceTension;
+    float timeStep = param_timeStep;
 
-    // Use override dt if provided, else the configured param_timeStep
-    float timeStep = (overrideDt > 0.0f ? overrideDt : param_timeStep);
-
-    // Optional ghosts sync
+    // No CPU ghost activation in fast path
     if (param_enableGhosts) {
         DownloadDataFromGPU();
         UpdateGhostParticlesDynamic(h);
@@ -402,12 +293,11 @@ void SPHFluidGPU::DispatchCompute(float overrideDt) {
     glDispatchCompute((numCells + 255) / 256, 1, 1);
     glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
 
-    // 2) Build grid (use AABB-fit for rotated box)
+    // 2) Build grid
     glUseProgram(buildGridShader);
     glUniform3i(glGetUniformLocation(buildGridShader, "gridSize"), gridSizeX, gridSizeY, gridSizeZ);
     glUniform1f(glGetUniformLocation(buildGridShader, "cellSize"), cellSize);
-    const Vec3 halfAA = ComputeAABBFittedHalf();
-    const Vec3 gridMin = param_boxCenter - halfAA;
+    const Vec3 gridMin = param_boxCenter - param_boxHalf;
     glUniform3f(glGetUniformLocation(buildGridShader, "gridMin"), gridMin.x, gridMin.y, gridMin.z);
     glUniform1i(glGetUniformLocation(buildGridShader, "numParticles"), int(particles.size()));
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, ssbo);
@@ -418,11 +308,9 @@ void SPHFluidGPU::DispatchCompute(float overrideDt) {
     glDispatchCompute((particles.size() + 255) / 256, 1, 1);
     glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
 
-    if (param_enableSort) {
-        RadixSortByCell();
-    }
+    if (param_enableSort) RadixSortByCell();
 
-    // 4) SPH step
+    // 3) SPH step
     glUseProgram(sphGridShader);
     glUniform3i(glGetUniformLocation(sphGridShader, "gridSize"), gridSizeX, gridSizeY, gridSizeZ);
     glUniform1f(glGetUniformLocation(sphGridShader, "cellSize"), cellSize);
@@ -435,7 +323,6 @@ void SPHFluidGPU::DispatchCompute(float overrideDt) {
     glUniform1f(glGetUniformLocation(sphGridShader, "viscosity"), viscosity);
     glUniform3f(glGetUniformLocation(sphGridShader, "gravity"), gravity.x, gravity.y, gravity.z);
     glUniform1f(glGetUniformLocation(sphGridShader, "surfaceTension"), surfaceTension);
-    glUniform1f(glGetUniformLocation(sphGridShader, "box"), box);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, ssbo);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, cellHeadSSBO);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 2, particleNextSSBO);
@@ -443,12 +330,14 @@ void SPHFluidGPU::DispatchCompute(float overrideDt) {
     glDispatchCompute((particles.size() + 255) / 256, 1, 1);
     glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
 
-    // 5) OBB constraints
+    // 4) OBB constraints (use cached rotation)
+    UpdateCachedBoxIfNeeded();
     glUseProgram(obbConstraintShader);
-    float R[9]; MakeRotationMat3XYZ(param_boxEulerDeg.x, param_boxEulerDeg.y, param_boxEulerDeg.z, R);
-    glUniformMatrix3fv(glGetUniformLocation(obbConstraintShader, "uBoxRot"), 1, GL_FALSE, R);
-    glUniform3f(glGetUniformLocation(obbConstraintShader, "uBoxCenter"), param_boxCenter.x, param_boxCenter.y, param_boxCenter.z);
-    glUniform3f(glGetUniformLocation(obbConstraintShader, "uBoxHalf"), param_boxHalf.x, param_boxHalf.y, param_boxHalf.z);
+    glUniformMatrix3fv(glGetUniformLocation(obbConstraintShader, "uBoxRot"), 1, GL_FALSE, cachedRot3x3);
+    glUniform3f(glGetUniformLocation(obbConstraintShader, "uBoxCenter"),
+        param_boxCenter.x, param_boxCenter.y, param_boxCenter.z);
+    glUniform3f(glGetUniformLocation(obbConstraintShader, "uBoxHalf"),
+        param_boxHalf.x, param_boxHalf.y, param_boxHalf.z);
     glUniform1f(glGetUniformLocation(obbConstraintShader, "uRestitution"), param_wallRestitution);
     glUniform1f(glGetUniformLocation(obbConstraintShader, "uFriction"), param_wallFriction);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, ssbo);
@@ -458,136 +347,85 @@ void SPHFluidGPU::DispatchCompute(float overrideDt) {
     glUseProgram(0);
 }
 
-GLuint SPHFluidGPU::GetFluidVBO() const { return fluidVBO; }
+void SPHFluidGPU::ApplyWaveImpulseGPU(float amplitude, float wavelength, float phase,
+    const Vec3& dir, float yMin, float yMax)
+{
+    if (amplitude == 0.0f || wavelength <= 1e-6f) return;
+    glUseProgram(waveImpulseShader);
+    glUniform1f(glGetUniformLocation(waveImpulseShader, "amplitude"), amplitude);
+    glUniform1f(glGetUniformLocation(waveImpulseShader, "wavelength"), wavelength);
+    glUniform1f(glGetUniformLocation(waveImpulseShader, "phase"), phase);
+    glUniform3f(glGetUniformLocation(waveImpulseShader, "dir"), dir.x, dir.y, dir.z);
+    glUniform1f(glGetUniformLocation(waveImpulseShader, "yMin"), yMin);
+    glUniform1f(glGetUniformLocation(waveImpulseShader, "yMax"), yMax);
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, ssbo);
+    glDispatchCompute((particles.size() + 255) / 256, 1, 1);
+    glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT); // velocities used next SPH step
+    glUseProgram(0);
+}
+
+GLuint SPHFluidGPU::GetFluidVBO()  const { return fluidVBO; }
 size_t SPHFluidGPU::GetNumFluids() const { return numFluids; }
 
 GLuint SPHFluidGPU::LoadComputeShader(const char* filePath) {
     std::ifstream file(filePath);
-    if (!file.is_open()) {
-        Debug::FatalError("Failed to open compute shader file", __FILE__, __LINE__);
-    }
-    std::stringstream ss;
-    ss << file.rdbuf();
+    if (!file.is_open()) { Debug::FatalError("Failed to open compute shader file", __FILE__, __LINE__); }
+    std::stringstream ss; ss << file.rdbuf();
     std::string sourceStr = ss.str();
     const char* source = sourceStr.c_str();
 
     GLuint shader = glCreateShader(GL_COMPUTE_SHADER);
     glShaderSource(shader, 1, &source, nullptr);
     glCompileShader(shader);
-
-    GLint isCompiled = 0;
-    glGetShaderiv(shader, GL_COMPILE_STATUS, &isCompiled);
-    if (!isCompiled) {
-        GLint maxLength = 0;
-        glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &maxLength);
-        std::string errorLog(maxLength, ' ');
-        glGetShaderInfoLog(shader, maxLength, &maxLength, &errorLog[0]);
+    GLint ok = 0; glGetShaderiv(shader, GL_COMPILE_STATUS, &ok);
+    if (!ok) {
+        GLint maxLen = 0; glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &maxLen);
+        std::string log(maxLen, ' '); glGetShaderInfoLog(shader, maxLen, &maxLen, &log[0]);
         glDeleteShader(shader);
-        Debug::FatalError("Compute shader compilation failed:\n" + errorLog, __FILE__, __LINE__);
+        Debug::FatalError("Compute shader compilation failed:\n" + log, __FILE__, __LINE__);
     }
-
-    GLuint program = glCreateProgram();
-    glAttachShader(program, shader);
-    glLinkProgram(program);
+    GLuint prog = glCreateProgram();
+    glAttachShader(prog, shader);
+    glLinkProgram(prog);
     glDeleteShader(shader);
-
-    GLint isLinked = 0;
-    glGetProgramiv(program, GL_LINK_STATUS, &isLinked);
-    if (!isLinked) {
-        GLint maxLength = 0;
-        glGetProgramiv(program, GL_INFO_LOG_LENGTH, &maxLength);
-        std::string errorLog(maxLength, ' ');
-        glGetProgramInfoLog(program, maxLength, &maxLength, &errorLog[0]);
-        glDeleteProgram(program);
-        Debug::FatalError("Compute shader link failed:\n" + errorLog, __FILE__, __LINE__);
+    GLint linked = 0; glGetProgramiv(prog, GL_LINK_STATUS, &linked);
+    if (!linked) {
+        GLint maxLen = 0; glGetProgramiv(prog, GL_INFO_LOG_LENGTH, &maxLen);
+        std::string log(maxLen, ' '); glGetProgramInfoLog(prog, maxLen, &maxLen, &log[0]);
+        glDeleteProgram(prog);
+        Debug::FatalError("Compute shader link failed:\n" + log, __FILE__, __LINE__);
     }
-
-    return program;
+    return prog;
 }
 
 void SPHFluidGPU::BuildGhostGrids() {
-    float spacing = std::max(1e-6f, param_h * 0.85f);
-    int cells = std::max(1, int(std::ceil((2.0f * box) / spacing)) + 1);
+    float spacing = param_h * 0.85f;
+    int cells = int(ceil((2.0f * box) / spacing)) + 1;
 
-    // X faces: grid in (y, z)
     ghostXNeg.init(-box, -box, spacing, cells, cells);
     ghostXPos.init(-box, -box, spacing, cells, cells);
-    // Y faces: grid in (x, z)
     ghostYNeg.init(-box, -box, spacing, cells, cells);
     ghostYPos.init(-box, -box, spacing, cells, cells);
-    // Z faces: grid in (x, y)
     ghostZNeg.init(-box, -box, spacing, cells, cells);
     ghostZPos.init(-box, -box, spacing, cells, cells);
 
     for (size_t i = 0; i < particles.size(); ++i) {
         const SPHParticle& p = particles[i];
         if (!p.isGhost) continue;
-        if (fabsf(p.pos.x + box) < 1e-4f) ghostXNeg.addGhost(p.pos.y, p.pos.z, i);
-        if (fabsf(p.pos.x - box) < 1e-4f) ghostXPos.addGhost(p.pos.y, p.pos.z, i);
-        if (fabsf(p.pos.y + box) < 1e-4f) ghostYNeg.addGhost(p.pos.x, p.pos.z, i);
-        if (fabsf(p.pos.y - box) < 1e-4f) ghostYPos.addGhost(p.pos.x, p.pos.z, i);
-        if (fabsf(p.pos.z + box) < 1e-4f) ghostZNeg.addGhost(p.pos.x, p.pos.y, i);
-        if (fabsf(p.pos.z - box) < 1e-4f) ghostZPos.addGhost(p.pos.x, p.pos.y, i);
+        if (fabs(p.pos.x + box) < 1e-4f) ghostXNeg.addGhost(p.pos.y, p.pos.z, i);
+        if (fabs(p.pos.x - box) < 1e-4f) ghostXPos.addGhost(p.pos.y, p.pos.z, i);
+        if (fabs(p.pos.y + box) < 1e-4f) ghostYNeg.addGhost(p.pos.x, p.pos.z, i);
+        if (fabs(p.pos.y - box) < 1e-4f) ghostYPos.addGhost(p.pos.x, p.pos.z, i);
+        if (fabs(p.pos.z + box) < 1e-4f) ghostZNeg.addGhost(p.pos.x, p.pos.y, i);
+        if (fabs(p.pos.z - box) < 1e-4f) ghostZPos.addGhost(p.pos.x, p.pos.y, i);
     }
 }
 
-// NEW: sine-wave velocity kick
-void SPHFluidGPU::ApplyWaveImpulse(float amplitude, float wavelength, float phase, const Vec3& dir,
-    float yMin, float yMax)
-{
-    if (amplitude == 0.0f || wavelength <= 1e-6f) return;
-
-    // Bring CPU side in sync, modify CPU buffer, push back to GPU.
-    DownloadDataFromGPU();
-
-    const float k = 2.0f * float(M_PI) / wavelength;
-    Vec3 nDir = dir;
-    float len = sqrtf(nDir.x * nDir.x + nDir.y * nDir.y + nDir.z * nDir.z);
-    if (len > 0.0f) { nDir /= len; }
-    else { nDir = Vec3(0, 1, 0); }
-
-    for (auto& p : particles) {
-        if (p.isGhost) continue;
-        if (p.pos.y < yMin || p.pos.y > yMax) continue;
-
-        // Phase using x+z to create ripples across the surface
-        float theta = k * (p.pos.x + p.pos.z) + phase;
-        float kick = amplitude * sinf(theta);
-
-        p.vel.x += nDir.x * kick;
-        p.vel.y += nDir.y * kick;
-        p.vel.z += nDir.z * kick;
-    }
-
-    // Upload updated particle velocities
+// --- kept for completeness (not used when param_enableGhosts=false)
+void SPHFluidGPU::ActivateClosestGhost(float, float, float) {}
+void SPHFluidGPU::UpdateGhostParticlesDynamic(float) {}
+void SPHFluidGPU::UploadGhostActivityToGPU() {
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, ssbo);
     glBufferSubData(GL_SHADER_STORAGE_BUFFER, 0, sizeof(SPHParticle) * particles.size(), particles.data());
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
-}
-
-// NEW: full reset of particle set and buffers
-void SPHFluidGPU::ResetSimulation()
-{
-    // Destroy GPU buffers we own
-    if (fluidVBO) { glBindBuffer(GL_ARRAY_BUFFER, 0); glDeleteBuffers(1, &fluidVBO); fluidVBO = 0; vboPtr = nullptr; }
-    if (ssbo) { glDeleteBuffers(1, &ssbo); ssbo = 0; }
-    if (cellHeadSSBO) { glDeleteBuffers(1, &cellHeadSSBO); cellHeadSSBO = 0; }
-    if (particleNextSSBO) { glDeleteBuffers(1, &particleNextSSBO); particleNextSSBO = 0; }
-    if (particleCellSSBO) { glDeleteBuffers(1, &particleCellSSBO); particleCellSSBO = 0; }
-    if (cellKeySSBO) { glDeleteBuffers(1, &cellKeySSBO); cellKeySSBO = 0; }
-    if (sortIdxSSBO) { glDeleteBuffers(1, &sortIdxSSBO); sortIdxSSBO = 0; }
-    if (sortTmpSSBO) { glDeleteBuffers(1, &sortTmpSSBO); sortTmpSSBO = 0; }
-
-    // Rebuild in the same order as the ctor to keep sizes consistent
-    InitializeParticles();          // fills 'particles', sets 'box'
-    InitializeGridAndBuffers();     // sizes per-cell/per-particle SSBOs from particles.size()
-    UploadDataToGPU();              // alloc+upload main SSBO (binding=0)
-    InitializeSortBuffers();        // alloc sort buffers using particles.size()
-    InitializeFluidVBO();           // alloc fluid-only VBO (numFluids)
-
-    // Optional: print sizes for quick sanity
-    std::cout << "Reset: particles=" << particles.size()
-        << " fluids=" << numFluids
-        << " grid=" << gridSizeX << "x" << gridSizeY << "x" << gridSizeZ
-        << " cells=" << numCells << std::endl;
 }

--- a/ComponentFramework/SPHFluid3D.h
+++ b/ComponentFramework/SPHFluid3D.h
@@ -33,6 +33,7 @@ public:
     void RadixSortByCell();
     void ActivateClosestGhost(float x, float y, float z);
     void UpdateGhostParticlesDynamic(float h);
+    void UploadGhostActivityToGPU();
     void UploadDataToGPU();
     void DownloadDataFromGPU();
   

--- a/ComponentFramework/SPHFluid3D.h
+++ b/ComponentFramework/SPHFluid3D.h
@@ -2,24 +2,25 @@
 #include <vector>
 #include <Vector.h>
 #include <glad.h>
+#include <unordered_map>
 #include <tuple>
 #include <cfloat>
+#include <algorithm>
 
 using namespace MATH;
 
 struct SPHParticle {
-    Vec4 pos;        // 16
-    Vec4 vel;        // 16
-    Vec4 acc;        // 16
-    float density;   // 4
-    float pressure;  // 4
-    float padA;      // 4
-    float padB;      // 4
-    int   isGhost;   // 4
-    int   isActive;  // 4
-    int   padC;      // 4
-    int   pad0;      // 4
-    // 64 bytes
+    Vec4  pos;
+    Vec4  vel;
+    Vec4  acc;
+    float density;
+    float pressure;
+    float padA;
+    float padB;
+    int   isGhost;
+    int   isActive;
+    int   padC;
+    int   pad0;
 };
 
 class SPHFluidGPU {
@@ -27,36 +28,65 @@ public:
     SPHFluidGPU(size_t numParticles_);
     ~SPHFluidGPU();
 
-    // Simulation
-    void InitializeParticles();
-    void InitializeGridAndBuffers();
-    void InitializeSortBuffers();
-    void RecreateGridForBox();
-    void InitializeFluidVBO();
-    void UploadDataToGPU();
-    void DownloadDataFromGPU();          // available, but not used in fast path
-    void UpdateFluidVBOFromGPU();
-    void DispatchCompute();
-    void RadixSortByCell();
+    void   InitializeParticles();
+    void   InitializeFluidVBO();
+    void   InitializeGridAndBuffers();
+    void   InitializeSortBuffers();
+    void   RadixSortByCell();
 
-    // GPU-only wave impulse (replaces CPU readback version)
-    void ApplyWaveImpulseGPU(float amplitude, float wavelength, float phase,
-        const Vec3& dir, float yMin, float yMax);
+    void   ActivateClosestGhost(float x, float y, float z);
+    void   UpdateGhostParticlesDynamic(float h);
+    void   UploadGhostActivityToGPU();
+    void   UploadDataToGPU();
+    void   DownloadDataFromGPU();
 
-    // Rendering helpers
-    GLuint GetFluidVBO()  const;
+    void   UpdateFluidVBOFromGPU();
+    void   DispatchCompute(float overrideDt = -1.0f);
+    GLuint GetFluidVBO() const;
     size_t GetNumFluids() const;
+    std::vector<Vec3> GetPositions() const;
 
-    // Public so render code can bind them quickly
+    void   ApplyWaveImpulse(float amplitude, float wavelength, float phase, const Vec3& dir,
+        float yMin = -FLT_MAX, float yMax = FLT_MAX);
+    void   ResetSimulation();
+    void   RecreateGridForBox();
+
+    Vec3   ComputeAABBFittedHalf() const;
+
+    float box = 7.0f;
+    float cellSize = 0.0f;
+    int   gridSizeX = 1, gridSizeY = 1, gridSizeZ = 1;
+    int   numCells = 1;
+
+    std::vector<SPHParticle> particles;
+    size_t numParticles;
+
     GLuint ssbo = 0;
+    GLuint cellHeadSSBO = 0;
+    GLuint particleNextSSBO = 0;
+    GLuint particleCellSSBO = 0;
 
-    // Tunables (same defaults as before)
+    GLuint clearGridShader = 0;
+    GLuint buildGridShader = 0;
+    GLuint sphGridShader = 0;
+    GLuint obbConstraintShader = 0;
+    GLuint radixSortShader = 0;
+    GLuint waveImpulseShader = 0;
+
+    GLuint fluidVBO = 0;
+    float* vboPtr = nullptr;
+    size_t numFluids = 0;
+
+    GLuint cellKeySSBO = 0;
+    GLuint sortIdxSSBO = 0;
+    GLuint sortTmpSSBO = 0;
+
     float param_h = 0.28f;
     float param_mass = 13.8f;
     float param_restDensity = 1000.0f;
     float param_gasConstant = 2000.0f;
     float param_viscosity = 3.5f;
-    float param_gravityY = -980.0f;      // cm/s^2
+    float param_gravityY = -980.0f;
     float param_surfaceTension = 0.0728f;
     float param_timeStep = 0.001f;
     bool  param_pause = false;
@@ -64,84 +94,59 @@ public:
     bool  param_useJitter = true;
     float param_jitterAmp = 0.20f;
 
-    bool  param_enableGhosts = false;  // keep false to avoid CPU↔GPU sync
+    bool  param_enableGhosts = false;
     bool  param_enableSort = false;
 
-    // Oriented box (OBB)
     Vec3  param_boxCenter = Vec3(0, 0, 0);
     Vec3  param_boxHalf = Vec3(7, 7, 7);
     Vec3  param_boxEulerDeg = Vec3(0, 0, 0);
     float param_wallRestitution = 0.15f;
     float param_wallFriction = 0.02f;
 
-    // Grid
-    float box = 7.0f; // legacy half-size (kept for compatibility)
-    float cellSize = 0.0f;
-    int gridSizeX = 0, gridSizeY = 0, gridSizeZ = 0;
-    int numCells = 0;
-
-    // Particle buffer (fluid + ghosts)
-    std::vector<SPHParticle> particles;
-    size_t numParticles;
-
-    // SSBOs
-    GLuint cellHeadSSBO = 0;
-    GLuint particleNextSSBO = 0;
-    GLuint particleCellSSBO = 0;
-
-    // Sorting
-    GLuint cellKeySSBO = 0;
-    GLuint sortIdxSSBO = 0;
-    GLuint sortTmpSSBO = 0;
-    GLuint radixSortShader = 0;
-
-    // Compute shaders
-    GLuint clearGridShader = 0;
-    GLuint buildGridShader = 0;
-    GLuint sphGridShader = 0;
-    GLuint obbConstraintShader = 0;
-    GLuint waveImpulseShader = 0;   // NEW
-
-    // Instance rendering (fluids only)
-    GLuint fluidVBO = 0;
-    float* vboPtr = nullptr;
-    size_t numFluids = 0;
-
-    // Ghost helper grids (unchanged API)
-    struct GhostGrid2D {
-        float minA, minB, cellSize;
-        int cellsA, cellsB;
-        std::vector<std::vector<std::vector<size_t>>> grid;
-        GhostGrid2D() : minA(0), minB(0), cellSize(1), cellsA(0), cellsB(0) {}
-        void init(float minA_, float minB_, float cellSize_, int cellsA_, int cellsB_) {
-            minA = minA_; minB = minB_; cellSize = cellSize_; cellsA = cellsA_; cellsB = cellsB_;
-            grid.resize(cellsA, std::vector<std::vector<size_t>>(cellsB));
-        }
-        void addGhost(float a, float b, size_t idx) {
-            int ia = int((a - minA) / cellSize);
-            int ib = int((b - minB) / cellSize);
-            if (ia >= 0 && ia < cellsA && ib >= 0 && ib < cellsB) grid[ia][ib].push_back(idx);
-        }
-        const std::vector<size_t>& getCell(float a, float b) const {
-            static const std::vector<size_t> empty;
-            int ia = int((a - minA) / cellSize);
-            int ib = int((b - minB) / cellSize);
-            if (ia >= 0 && ia < cellsA && ib >= 0 && ib < cellsB) return grid[ia][ib];
-            return empty;
-        }
-    };
-    GhostGrid2D ghostXNeg, ghostXPos, ghostYNeg, ghostYPos, ghostZNeg, ghostZPos;
-    void BuildGhostGrids();
-
 private:
     GLuint LoadComputeShader(const char* filePath);
 
-    // Cached OBB rotation to avoid sin/cos every substep
+    /* -------- Ghost face 2D acceleration grids --------
+       Each axis-aligned face gets a 2D grid storing indices of the ghost particles
+       lying on that face.  Used for quick neighbor / activation queries. */
+    struct GhostGrid2D {
+        float minA = 0, minB = 0, cellSize = 1;
+        int   cellsA = 0, cellsB = 0;
+        // Flattened (b * cellsA + a) -> vector of particle indices
+        std::vector<std::vector<size_t>> buckets;
+
+        void init(float minA_, float minB_, float cellSz_, int cA_, int cB_) {
+            minA = minA_; minB = minB_; cellSize = cellSz_; cellsA = cA_; cellsB = cB_;
+            buckets.clear();
+            buckets.resize(std::max(1, cellsA * cellsB));
+        }
+        inline int toIndex(int ia, int ib) const { return ib * cellsA + ia; }
+
+        void addGhost(float a, float b, size_t idx) {
+            int ia = int((a - minA) / cellSize);
+            int ib = int((b - minB) / cellSize);
+            ia = std::clamp(ia, 0, cellsA - 1);
+            ib = std::clamp(ib, 0, cellsB - 1);
+            buckets[toIndex(ia, ib)].push_back(idx);
+        }
+
+        const std::vector<size_t>& getCell(float a, float b) const {
+            static const std::vector<size_t> empty;
+            if (cellsA == 0 || cellsB == 0) return empty;
+            int ia = int((a - minA) / cellSize);
+            int ib = int((b - minB) / cellSize);
+            if (ia < 0 || ib < 0 || ia >= cellsA || ib >= cellsB) return empty;
+            return buckets[toIndex(ia, ib)];
+        }
+    };
+
+    GhostGrid2D ghostXNeg, ghostXPos;
+    GhostGrid2D ghostYNeg, ghostYPos;
+    GhostGrid2D ghostZNeg, ghostZPos;
+
+    void BuildGhostGrids();
+
+    // Cached OBB rotation
     float cachedRot3x3[9] = { 1,0,0, 0,1,0, 0,0,1 };
-    Vec3  cachedBoxCenter{}, cachedBoxHalf{}, cachedBoxEuler{};
     void  UpdateCachedBoxIfNeeded();
-    static void MakeRotationMat3XYZ(float rxDeg, float ryDeg, float rzDeg, float outM[9]);
-    void   ActivateClosestGhost(float x, float y, float z); // kept for completeness
-    void   UpdateGhostParticlesDynamic(float h);
-    void   UploadGhostActivityToGPU();
 };

--- a/ComponentFramework/SPHFluid3D.h
+++ b/ComponentFramework/SPHFluid3D.h
@@ -52,6 +52,8 @@ public:
     // NEW: rebuild grid only (when box/h changes), doesn’t touch particles
     void RecreateGridForBox();
 
+    MATH::Vec3 ComputeAABBFittedHalf() const;
+
     // Simulation/box/grid properties
     // Legacy 'box' kept for compatibility (half-size max extent), used as fallback
     float box = 7.0f; // size of bucket ([-box, box]) legacy

--- a/ComponentFramework/SPHFluid3D.h
+++ b/ComponentFramework/SPHFluid3D.h
@@ -2,11 +2,11 @@
 #include <vector>
 #include <Vector.h>
 #include <glad.h>
-#include <unordered_map>
 #include <tuple>
-#include <cfloat> // add
+#include <cfloat>
 
 using namespace MATH;
+
 struct SPHParticle {
     Vec4 pos;        // 16
     Vec4 vel;        // 16
@@ -15,10 +15,10 @@ struct SPHParticle {
     float pressure;  // 4
     float padA;      // 4
     float padB;      // 4
-    int isGhost;     // 4
-    int isActive;    // 4
-    int padC;        // 4
-    int pad0;        // 4
+    int   isGhost;   // 4
+    int   isActive;  // 4
+    int   padC;      // 4
+    int   pad0;      // 4
     // 64 bytes
 };
 
@@ -27,69 +27,30 @@ public:
     SPHFluidGPU(size_t numParticles_);
     ~SPHFluidGPU();
 
+    // Simulation
     void InitializeParticles();
-    void InitializeFluidVBO();
     void InitializeGridAndBuffers();
     void InitializeSortBuffers();
-    void RadixSortByCell();
-    void ActivateClosestGhost(float x, float y, float z);
-    void UpdateGhostParticlesDynamic(float h);
-    void UploadGhostActivityToGPU();
-    void UploadDataToGPU();
-    void DownloadDataFromGPU();
-
-    void UpdateFluidVBOFromGPU();
-    void DispatchCompute(float overrideDt = -1.0f);
-    GLuint GetFluidVBO() const;
-    size_t GetNumFluids() const;
-    std::vector<Vec3> GetPositions() const;
-
-    // wave + reset helpers
-    void ApplyWaveImpulse(float amplitude, float wavelength, float phase, const Vec3& dir,
-        float yMin = -FLT_MAX, float yMax = FLT_MAX);
-    void ResetSimulation();
-
-    // NEW: rebuild grid only (when box/h changes), doesn’t touch particles
     void RecreateGridForBox();
+    void InitializeFluidVBO();
+    void UploadDataToGPU();
+    void DownloadDataFromGPU();          // available, but not used in fast path
+    void UpdateFluidVBOFromGPU();
+    void DispatchCompute();
+    void RadixSortByCell();
 
-    MATH::Vec3 ComputeAABBFittedHalf() const;
+    // GPU-only wave impulse (replaces CPU readback version)
+    void ApplyWaveImpulseGPU(float amplitude, float wavelength, float phase,
+        const Vec3& dir, float yMin, float yMax);
 
-    // Simulation/box/grid properties
-    // Legacy 'box' kept for compatibility (half-size max extent), used as fallback
-    float box = 7.0f; // size of bucket ([-box, box]) legacy
-    float cellSize;
-    int gridSizeX, gridSizeY, gridSizeZ;
-    int numCells;
+    // Rendering helpers
+    GLuint GetFluidVBO()  const;
+    size_t GetNumFluids() const;
 
-    // Particle buffer (fluid + ghosts)
-    std::vector<SPHParticle> particles;
-    size_t numParticles;
-
-    // SSBOs
+    // Public so render code can bind them quickly
     GLuint ssbo = 0;
-    GLuint cellHeadSSBO = 0;
-    GLuint particleNextSSBO = 0;
-    GLuint particleCellSSBO = 0;
 
-    // Compute shaders
-    GLuint clearGridShader = 0;
-    GLuint buildGridShader = 0;
-    GLuint sphGridShader = 0;
-    // NEW: OBB constraint compute
-    GLuint obbConstraintShader = 0;
-
-    // Instance rendering (fluids only)
-    GLuint fluidVBO = 0;
-    float* vboPtr = nullptr;
-    size_t numFluids = 0;
-
-    // Sorting
-    GLuint cellKeySSBO = 0;
-    GLuint sortIdxSSBO = 0;
-    GLuint sortTmpSSBO = 0;
-    GLuint radixSortShader = 0;
-
-    // Tunable simulation parameters
+    // Tunables (same defaults as before)
     float param_h = 0.28f;
     float param_mass = 13.8f;
     float param_restDensity = 1000.0f;
@@ -100,60 +61,87 @@ public:
     float param_timeStep = 0.001f;
     bool  param_pause = false;
 
-    bool  param_useJitter = false;     // spawn jitter
+    bool  param_useJitter = true;
     float param_jitterAmp = 0.20f;
 
-    // Performance toggles
-    bool  param_enableGhosts = false; // disable to remove CPU↔GPU sync
-    bool  param_enableSort = false;   // not used by current SPH path
+    bool  param_enableGhosts = false;  // keep false to avoid CPU↔GPU sync
+    bool  param_enableSort = false;
 
-    // NEW: Oriented Box (OBB) controls
-    Vec3  param_boxCenter = Vec3(0.0f, 0.0f, 0.0f);
-    Vec3  param_boxHalf = Vec3(7.0f, 7.0f, 7.0f);
-    Vec3  param_boxEulerDeg = Vec3(0.0f, 0.0f, 0.0f); // XYZ degrees
-    float param_wallRestitution = 0.15f; // bounce
-    float param_wallFriction = 0.02f; // tangential damping
+    // Oriented box (OBB)
+    Vec3  param_boxCenter = Vec3(0, 0, 0);
+    Vec3  param_boxHalf = Vec3(7, 7, 7);
+    Vec3  param_boxEulerDeg = Vec3(0, 0, 0);
+    float param_wallRestitution = 0.15f;
+    float param_wallFriction = 0.02f;
 
-    // Ghost grid structures (unchanged, but note ghosts are axis-aligned)
+    // Grid
+    float box = 7.0f; // legacy half-size (kept for compatibility)
+    float cellSize = 0.0f;
+    int gridSizeX = 0, gridSizeY = 0, gridSizeZ = 0;
+    int numCells = 0;
+
+    // Particle buffer (fluid + ghosts)
+    std::vector<SPHParticle> particles;
+    size_t numParticles;
+
+    // SSBOs
+    GLuint cellHeadSSBO = 0;
+    GLuint particleNextSSBO = 0;
+    GLuint particleCellSSBO = 0;
+
+    // Sorting
+    GLuint cellKeySSBO = 0;
+    GLuint sortIdxSSBO = 0;
+    GLuint sortTmpSSBO = 0;
+    GLuint radixSortShader = 0;
+
+    // Compute shaders
+    GLuint clearGridShader = 0;
+    GLuint buildGridShader = 0;
+    GLuint sphGridShader = 0;
+    GLuint obbConstraintShader = 0;
+    GLuint waveImpulseShader = 0;   // NEW
+
+    // Instance rendering (fluids only)
+    GLuint fluidVBO = 0;
+    float* vboPtr = nullptr;
+    size_t numFluids = 0;
+
+    // Ghost helper grids (unchanged API)
     struct GhostGrid2D {
-    float minA, minB, cellSize;
-    int cellsA, cellsB;
-    std::vector<std::vector<std::vector<size_t>>> grid;
-
-    GhostGrid2D() : minA(0), minB(0), cellSize(1), cellsA(0), cellsB(0) {}
-
-    void init(float minA_, float minB_, float cellSize_, int cellsA_, int cellsB_) {
-        minA = minA_;
-        minB = minB_;
-        cellSize = cellSize_;
-        cellsA = std::max(1, cellsA_);
-        cellsB = std::max(1, cellsB_);
-
-        // Rebuild the full 2D shape so every row has exactly cellsB columns.
-        // Using assign() ensures old per-row sizes don’t linger after a reset.
-        grid.assign(cellsA, std::vector<std::vector<size_t>>(cellsB));
-    }
-
-    void addGhost(float a, float b, size_t idx) {
-        int ia = int((a - minA) / cellSize);
-        int ib = int((b - minB) / cellSize);
-        if (ia >= 0 && ia < cellsA && ib >= 0 && ib < cellsB)
-            grid[ia][ib].push_back(idx);
-    }
-    const std::vector<size_t>& getCell(float a, float b) const {
-        static const std::vector<size_t> empty;
-        int ia = int((a - minA) / cellSize);
-        int ib = int((b - minB) / cellSize);
-        if (ia >= 0 && ia < cellsA && ib >= 0 && ib < cellsB)
-            return grid[ia][ib];
-        return empty;
-    }
-};
-
+        float minA, minB, cellSize;
+        int cellsA, cellsB;
+        std::vector<std::vector<std::vector<size_t>>> grid;
+        GhostGrid2D() : minA(0), minB(0), cellSize(1), cellsA(0), cellsB(0) {}
+        void init(float minA_, float minB_, float cellSize_, int cellsA_, int cellsB_) {
+            minA = minA_; minB = minB_; cellSize = cellSize_; cellsA = cellsA_; cellsB = cellsB_;
+            grid.resize(cellsA, std::vector<std::vector<size_t>>(cellsB));
+        }
+        void addGhost(float a, float b, size_t idx) {
+            int ia = int((a - minA) / cellSize);
+            int ib = int((b - minB) / cellSize);
+            if (ia >= 0 && ia < cellsA && ib >= 0 && ib < cellsB) grid[ia][ib].push_back(idx);
+        }
+        const std::vector<size_t>& getCell(float a, float b) const {
+            static const std::vector<size_t> empty;
+            int ia = int((a - minA) / cellSize);
+            int ib = int((b - minB) / cellSize);
+            if (ia >= 0 && ia < cellsA && ib >= 0 && ib < cellsB) return grid[ia][ib];
+            return empty;
+        }
+    };
     GhostGrid2D ghostXNeg, ghostXPos, ghostYNeg, ghostYPos, ghostZNeg, ghostZPos;
     void BuildGhostGrids();
 
-
 private:
     GLuint LoadComputeShader(const char* filePath);
+
+    // Cached OBB rotation to avoid sin/cos every substep
+    float cachedRot3x3[9] = { 1,0,0, 0,1,0, 0,0,1 };
+    Vec3  cachedBoxCenter{}, cachedBoxHalf{}, cachedBoxEuler{};
+    void  UpdateCachedBoxIfNeeded();
+    static void MakeRotationMat3XYZ(float rxDeg, float ryDeg, float rzDeg, float outM[9]);
+    void   ActivateClosestGhost(float x, float y, float z); // kept for completeness
+    void   UpdateGhostParticlesDynamic(float h);
+    void   UploadGhostActivityToGPU();
 };

--- a/ComponentFramework/SPHFluid3D.h
+++ b/ComponentFramework/SPHFluid3D.h
@@ -1,9 +1,10 @@
-#pragma once
+﻿#pragma once
 #include <vector>
 #include <Vector.h>
 #include <glad.h>
 #include <unordered_map>
 #include <tuple>
+#include <cfloat> // add
 
 using namespace MATH;
 struct SPHParticle {
@@ -13,12 +14,12 @@ struct SPHParticle {
     float density;   // 4
     float pressure;  // 4
     float padA;      // 4
-    float padB;      // 4  // <-- Floats up to 16
+    float padB;      // 4
     int isGhost;     // 4
     int isActive;    // 4
     int padC;        // 4
-    int pad0;        // 4  // <-- Ints up to 16
-    // 16*3 + 16 + 16 = 64
+    int pad0;        // 4
+    // 64 bytes
 };
 
 class SPHFluidGPU {
@@ -36,15 +37,24 @@ public:
     void UploadGhostActivityToGPU();
     void UploadDataToGPU();
     void DownloadDataFromGPU();
-  
+
     void UpdateFluidVBOFromGPU();
     void DispatchCompute();
     GLuint GetFluidVBO() const;
     size_t GetNumFluids() const;
     std::vector<Vec3> GetPositions() const;
 
+    // wave + reset helpers
+    void ApplyWaveImpulse(float amplitude, float wavelength, float phase, const Vec3& dir,
+        float yMin = -FLT_MAX, float yMax = FLT_MAX);
+    void ResetSimulation();
+
+    // NEW: rebuild grid only (when box/h changes), doesn’t touch particles
+    void RecreateGridForBox();
+
     // Simulation/box/grid properties
-    float box = 7.0f; // size of bucket ([-box, box])
+    // Legacy 'box' kept for compatibility (half-size max extent), used as fallback
+    float box = 7.0f; // size of bucket ([-box, box]) legacy
     float cellSize;
     int gridSizeX, gridSizeY, gridSizeZ;
     int numCells;
@@ -54,48 +64,72 @@ public:
     size_t numParticles;
 
     // SSBOs
-    GLuint ssbo = 0;             // Particle buffer
-    GLuint cellHeadSSBO = 0;     // Cell head buffer
-    GLuint particleNextSSBO = 0; // Particle next buffer
-    GLuint particleCellSSBO = 0; // Particle cell index buffer
+    GLuint ssbo = 0;
+    GLuint cellHeadSSBO = 0;
+    GLuint particleNextSSBO = 0;
+    GLuint particleCellSSBO = 0;
 
     // Compute shaders
     GLuint clearGridShader = 0;
     GLuint buildGridShader = 0;
     GLuint sphGridShader = 0;
+    // NEW: OBB constraint compute
+    GLuint obbConstraintShader = 0;
 
+    // Instance rendering (fluids only)
     GLuint fluidVBO = 0;
     float* vboPtr = nullptr;
     size_t numFluids = 0;
 
-    GLuint cellKeySSBO = 0;      // Stores the grid cell index for each particle (int per particle)
-    GLuint sortIdxSSBO = 0;      // Stores sorted indices for particles (int per particle, ping-pong)
-    GLuint sortTmpSSBO = 0;      // Temporary buffer for radix sort (ping-pong)
+    // Sorting
+    GLuint cellKeySSBO = 0;
+    GLuint sortIdxSSBO = 0;
+    GLuint sortTmpSSBO = 0;
+    GLuint radixSortShader = 0;
 
-    GLuint radixSortShader = 0;  // GPU radix sort compute shade
+    // Tunable simulation parameters
+    float param_h = 0.28f;
+    float param_mass = 13.8f;
+    float param_restDensity = 1000.0f;
+    float param_gasConstant = 2000.0f;
+    float param_viscosity = 3.5f;
+    float param_gravityY = -980.0f;      // cm/s^2
+    float param_surfaceTension = 0.0728f;
+    float param_timeStep = 0.001f;
+    bool  param_pause = false;
 
-    // --- Ghost grid structures for each face ---
+    bool  param_useJitter = true;     // spawn jitter
+    float param_jitterAmp = 0.20f;
+
+    // Performance toggles
+    bool  param_enableGhosts = false; // disable to remove CPU↔GPU sync
+    bool  param_enableSort = false;   // not used by current SPH path
+
+    // NEW: Oriented Box (OBB) controls
+    Vec3  param_boxCenter = Vec3(0.0f, 0.0f, 0.0f);
+    Vec3  param_boxHalf = Vec3(7.0f, 7.0f, 7.0f);
+    Vec3  param_boxEulerDeg = Vec3(0.0f, 0.0f, 0.0f); // XYZ degrees
+    float param_wallRestitution = 0.15f; // bounce
+    float param_wallFriction = 0.02f; // tangential damping
+
+    // Ghost grid structures (unchanged, but note ghosts are axis-aligned)
     struct GhostGrid2D {
         float minA, minB, cellSize;
         int cellsA, cellsB;
-        // Each cell holds a vector of indices into the particles vector
-        std::vector<std::vector<std::vector<size_t>>> grid; // [a][b][ghost indices]
+        std::vector<std::vector<std::vector<size_t>>> grid;
 
         GhostGrid2D() : minA(0), minB(0), cellSize(1), cellsA(0), cellsB(0) {}
-
         void init(float minA_, float minB_, float cellSize_, int cellsA_, int cellsB_) {
             minA = minA_; minB = minB_; cellSize = cellSize_;
             cellsA = cellsA_; cellsB = cellsB_;
             grid.resize(cellsA, std::vector<std::vector<size_t>>(cellsB));
         }
-
         void addGhost(float a, float b, size_t idx) {
             int ia = int((a - minA) / cellSize);
             int ib = int((b - minB) / cellSize);
             if (ia >= 0 && ia < cellsA && ib >= 0 && ib < cellsB)
                 grid[ia][ib].push_back(idx);
         }
-
         const std::vector<size_t>& getCell(float a, float b) const {
             static const std::vector<size_t> empty;
             int ia = int((a - minA) / cellSize);
@@ -107,8 +141,8 @@ public:
     };
 
     GhostGrid2D ghostXNeg, ghostXPos, ghostYNeg, ghostYPos, ghostZNeg, ghostZPos;
+    void BuildGhostGrids();
 
-    void BuildGhostGrids(); // new
 
 private:
     GLuint LoadComputeShader(const char* filePath);

--- a/ComponentFramework/Scene0p.cpp
+++ b/ComponentFramework/Scene0p.cpp
@@ -45,7 +45,7 @@ bool Scene0p::OnCreate() {
     viewMatrix = MMath::lookAt(cameraPos, cameraTarget, cameraUp);
     modelMatrix.loadIdentity();
 
-    fluidGPU = new SPHFluidGPU(50000); // ? You can increase this!
+    fluidGPU = new SPHFluidGPU(20000); // ? You can increase this!
 
     return true;
 }

--- a/ComponentFramework/Scene0p.cpp
+++ b/ComponentFramework/Scene0p.cpp
@@ -60,7 +60,7 @@ bool Scene0p::OnCreate() {
     viewMatrix = MMath::lookAt(cameraPos, cameraTarget, cameraUp);
     modelMatrix.loadIdentity();
 
-    fluidGPU = new SPHFluidGPU(30000);
+    fluidGPU = new SPHFluidGPU(50000);
     mesh->BindInstanceBuffer(fluidGPU->GetFluidVBO(), static_cast<GLsizei>(sizeof(float) * 4));
 
     lineShader = new Shader("shaders/lineVert.glsl", "shaders/lineFrag.glsl");
@@ -187,7 +187,7 @@ void Scene0p::Update(const float deltaTime) {
         fluidGPU->param_gravityY = -980.0f;
         fluidGPU->param_surfaceTension = 0.12f;
         fluidGPU->param_timeStep = 5.0e-4f;
-        fluidGPU->param_useJitter = true;
+        fluidGPU->param_useJitter = false;
         fluidGPU->param_jitterAmp = 0.06f;
         fluidGPU->param_wallRestitution = 0.05f;
         fluidGPU->param_wallFriction = 0.05f;

--- a/ComponentFramework/Scene0p.cpp
+++ b/ComponentFramework/Scene0p.cpp
@@ -11,7 +11,8 @@
 #include "imgui.h"
 #include "imgui_impl_sdl2.h"
 #include "SceneManager.h"
-
+#include <limits>
+#include <algorithm>
 
 Scene0p::Scene0p() :
     sphere{ nullptr }, shader{ nullptr }, mesh{ nullptr },
@@ -41,11 +42,27 @@ bool Scene0p::OnCreate() {
         return false;
     }
 
+    // Ensure the shader storage block used by the vertex shader is bound to binding = 0
+    {
+        GLuint prog = shader->GetProgram();
+        GLuint block = glGetProgramResourceIndex(prog, GL_SHADER_STORAGE_BLOCK, "ParticleBuf");
+        if (block != GL_INVALID_INDEX) {
+            glShaderStorageBlockBinding(prog, block, 0);
+        }
+        else {
+            std::cerr << "SSBO block 'ParticleBuf' not found in program\n";
+        }
+    }
+
     projectionMatrix = MMath::perspective(45.0f, 16.0f / 9.0f, 0.5f, 100.0f);
     viewMatrix = MMath::lookAt(cameraPos, cameraTarget, cameraUp);
     modelMatrix.loadIdentity();
 
-    fluidGPU = new SPHFluidGPU(30000); // ? You can increase this!
+    // Create fluid system (allocates SSBOs and compute pipelines)
+    fluidGPU = new SPHFluidGPU(30000);
+
+    // Optional: enable legacy instancing fallback (useSSBO == 0)
+    // mesh->BindInstanceBuffer(fluidGPU->GetFluidVBO(), sizeof(float) * 4);
 
     return true;
 }
@@ -91,24 +108,155 @@ void Scene0p::HandleEvents(const SDL_Event& sdlEvent) {
 void Scene0p::Update(const float deltaTime) {
     ballAnimTime += deltaTime;
     float ballX = std::sin(ballAnimTime) * 3.0f;
-    if (sphere) {
-        sphere->SetPosition(Vec3(ballX, 0.0f, 0.0f));
-    }
-
+    if (sphere) { sphere->SetPosition(Vec3(ballX, 0.0f, 0.0f)); }
     viewMatrix = MMath::lookAt(cameraPos, cameraTarget, cameraUp);
 
     if (fluidGPU) {
-        fluidGPU->DispatchCompute();
-        fluidGPU->UpdateFluidVBOFromGPU();
+        ImGui::Begin("Fluid Controls");
+        ImGui::Text("FPS: %.1f", ImGui::GetIO().Framerate);
+        ImGui::Text("Particles: %zu (fluids: %zu)", fluidGPU->particles.size(), fluidGPU->GetNumFluids());
+        ImGui::Separator();
 
-        std::vector<Vec3> velocities;
-        velocities.reserve(fluidGPU->particles.size());
-        for (const auto& p : fluidGPU->particles) {
-            if (p.isGhost == 0) {
-                velocities.emplace_back(p.vel.x, p.vel.y, p.vel.z);
+        if (ImGui::Button("Preset: Stable Water")) {
+            fluidGPU->param_pause = false;
+            fluidGPU->param_h = 0.28f;
+            fluidGPU->param_restDensity = 1000.0f;
+            fluidGPU->param_gasConstant = 2000.0f;
+            fluidGPU->param_viscosity = 3.5f;
+            fluidGPU->param_gravityY = -9.81f;
+            fluidGPU->param_surfaceTension = 0.0f;
+            fluidGPU->param_timeStep = 2e-4f;
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Fit Camera")) {
+            Vec3 minV(std::numeric_limits<float>::max(),
+                std::numeric_limits<float>::max(),
+                std::numeric_limits<float>::max());
+            Vec3 maxV(-std::numeric_limits<float>::max(),
+                -std::numeric_limits<float>::max(),
+                -std::numeric_limits<float>::max());
+            size_t count = 0;
+            for (const auto& p : fluidGPU->particles) {
+                if (p.isGhost) continue;
+                minV.x = std::min(minV.x, p.pos.x);
+                minV.y = std::min(minV.y, p.pos.y);
+                minV.z = std::min(minV.z, p.pos.z);
+                maxV.x = std::max(maxV.x, p.pos.x);
+                maxV.y = std::max(maxV.y, p.pos.y);
+                maxV.z = std::max(maxV.z, p.pos.z);
+                ++count;
+            }
+            if (count > 0) {
+                Vec3 center((minV.x + maxV.x) * 0.5f,
+                    (minV.y + maxV.y) * 0.5f,
+                    (minV.z + maxV.z) * 0.5f);
+                float height = (maxV.y - minV.y);
+                float width = (maxV.x - minV.x);
+                const float fovY = 45.0f * (3.14159265359f / 180.0f);
+                float halfH = std::max(height, width) * 0.5f;
+                float dist = halfH / std::tan(fovY * 0.5f) * 1.35f;
+                cameraTarget = center;
+                cameraPos = Vec3(center.x, center.y, center.z + dist);
             }
         }
-        mesh->SetInstanceVelocities(velocities);
+
+        // Sim params
+        ImGui::Checkbox("Pause simulation", &fluidGPU->param_pause);
+        ImGui::SliderFloat("h (smoothing)", &fluidGPU->param_h, 0.10f, 1.00f);
+        ImGui::SliderFloat("mass", &fluidGPU->param_mass, 1.0f, 50.0f);
+        ImGui::SliderFloat("restDensity", &fluidGPU->param_restDensity, 100.0f, 2000.0f);
+        ImGui::SliderFloat("gasConstant", &fluidGPU->param_gasConstant, 100.0f, 30000.0f);
+        ImGui::SliderFloat("viscosity", &fluidGPU->param_viscosity, 0.0f, 20.0f);
+        ImGui::SliderFloat("gravityY", &fluidGPU->param_gravityY, -5000.0f, 0.0f);
+        ImGui::SliderFloat("surfaceTension", &fluidGPU->param_surfaceTension, 0.0f, 1.0f);
+        ImGui::SliderFloat("timeStep", &fluidGPU->param_timeStep, 1e-5f, 5e-3f, "%.6f", ImGuiSliderFlags_Logarithmic);
+
+        // Performance toggles
+        static bool useSSBO = true; // fast path (render)
+        ImGui::Separator();
+        ImGui::Text("Performance");
+        ImGui::Checkbox("Render from SSBO (fast)", &useSSBO);
+        ImGui::Checkbox("Enable ghost boundaries (slower)", &fluidGPU->param_enableGhosts);
+        ImGui::SameLine();
+        ImGui::Checkbox("Enable grid sort (unused)", &fluidGPU->param_enableSort);
+
+        // Box transform (move/resize/rotate)
+        ImGui::Separator();
+        ImGui::Text("Box Transform (OBB)");
+        ImGui::DragFloat3("Center", &fluidGPU->param_boxCenter.x, 0.05f);
+        ImGui::DragFloat3("Half Extents", &fluidGPU->param_boxHalf.x, 0.05f, 0.05f, 100.0f);
+        ImGui::DragFloat3("Euler XYZ (deg)", &fluidGPU->param_boxEulerDeg.x, 0.5f, -180.0f, 180.0f);
+        ImGui::SliderFloat("Wall Restitution", &fluidGPU->param_wallRestitution, 0.0f, 1.0f);
+        ImGui::SliderFloat("Wall Friction", &fluidGPU->param_wallFriction, 0.0f, 1.0f);
+        if (ImGui::Button("Rebuild Grid for Box")) {
+            fluidGPU->RecreateGridForBox();
+        }
+
+        // Spawn layout
+        ImGui::Separator();
+        ImGui::Text("Spawn Layout");
+        ImGui::Checkbox("Use jitter", &fluidGPU->param_useJitter);
+        ImGui::SameLine();
+        ImGui::SliderFloat("Jitter amp * spacing", &fluidGPU->param_jitterAmp, 0.0f, 0.5f, "%.2f");
+        ImGui::SameLine();
+        if (ImGui::Button("Rebuild Layout")) {
+            fluidGPU->ResetSimulation();
+        }
+
+        // Waves
+        ImGui::Separator();
+        ImGui::Text("Waves");
+        static float waveAmplitude = 1.5f;
+        static float waveWavelength = 3.0f;
+        static float wavePhaseSpeed = 4.0f;
+        static int waveDirIdx = 1;
+        static float yBandMin = -std::numeric_limits<float>::infinity();
+        static float yBandMax = std::numeric_limits<float>::infinity();
+        static bool continuousWave = false;
+        static float wavePhase = 0.0f;
+
+        ImGui::SliderFloat("Amplitude", &waveAmplitude, 0.0f, 25.0f);
+        ImGui::SliderFloat("Wavelength", &waveWavelength, 0.5f, 10.0f);
+        ImGui::SliderFloat("Phase speed", &wavePhaseSpeed, 0.0f, 20.0f);
+        ImGui::RadioButton("Dir X", &waveDirIdx, 0); ImGui::SameLine();
+        ImGui::RadioButton("Dir Y", &waveDirIdx, 1); ImGui::SameLine();
+        ImGui::RadioButton("Dir Z", &waveDirIdx, 2);
+        ImGui::InputFloat("Band Y min", &yBandMin);
+        ImGui::InputFloat("Band Y max", &yBandMax);
+        ImGui::Checkbox("Continuous wave (CPU sync)", &continuousWave);
+        if (ImGui::Button("Impulse Now")) {
+            Vec3 dir = (waveDirIdx == 0) ? Vec3(1, 0, 0) : (waveDirIdx == 1) ? Vec3(0, 1, 0) : Vec3(0, 0, 1);
+            fluidGPU->ApplyWaveImpulse(waveAmplitude, waveWavelength, wavePhase, dir, yBandMin, yBandMax);
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Reset Simulation")) {
+            fluidGPU->ResetSimulation();
+        }
+
+        // Visualization
+        ImGui::Separator();
+        ImGui::Text("Visualization");
+        static int vizMode = 1;
+        static float rangeMin = 0.0f, rangeMax = 10.0f;
+        ImGui::Combo("Color by", &vizMode, "Depth\0Speed\0Pressure\0Density\0\0");
+        ImGui::DragFloat("Range Min", &rangeMin, 0.1f);
+        ImGui::DragFloat("Range Max", &rangeMax, 0.1f);
+        ImGui::TextDisabled("Tip: SSBO mode avoids CPU readbacks and boosts FPS.");
+
+        ImGui::End();
+
+        if (continuousWave) {
+            wavePhase += wavePhaseSpeed * deltaTime;
+            Vec3 dir = (waveDirIdx == 0) ? Vec3(1, 0, 0) : (waveDirIdx == 1) ? Vec3(0, 1, 0) : Vec3(0, 0, 1);
+            fluidGPU->ApplyWaveImpulse(waveAmplitude, waveWavelength, wavePhase, dir, yBandMin, yBandMax);
+        }
+
+        // Sim step
+        fluidGPU->DispatchCompute();
+
+        if (!useSSBO) {
+            fluidGPU->UpdateFluidVBOFromGPU();
+        }
     }
 }
 
@@ -116,32 +264,28 @@ void Scene0p::Render() const {
     glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-    if (drawInWireMode) {
-        glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
-    }
-    else {
-        glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
-    }
+    if (drawInWireMode) glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+    else glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 
     glUseProgram(shader->GetProgram());
     glUniformMatrix4fv(shader->GetUniformID("projectionMatrix"), 1, GL_FALSE, projectionMatrix);
     glUniformMatrix4fv(shader->GetUniformID("viewMatrix"), 1, GL_FALSE, viewMatrix);
 
     if (fluidGPU && mesh) {
-        // 1. Get the mapped VBO (must hold only fluid particle positions)
-        GLuint vbo = fluidGPU->GetFluidVBO();       // returns VBO for instance positions
-        size_t numInstances = fluidGPU->GetNumFluids(); // returns fluid particle count
+        // Ensure the SSBO used by the vertex shader is bound at binding=0
+        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, fluidGPU->ssbo);
 
-        // 2. Bind the instance buffer for position (vec4 per instance)
-        mesh->BindInstanceBuffer(vbo, sizeof(Vec4)); // or 4 * sizeof(float)
+        glUniform1i(shader->GetUniformID("useSSBO"), 1);
+        glUniform1i(shader->GetUniformID("colorMode"), 1); // Speed
+        glUniform2f(shader->GetUniformID("vizRange"), 0.0f, 10.0f);
 
-        // 3. Set scale/model matrix as usual
-        Matrix4 scaleMat = MMath::scale(0.1f, 0.1f, 0.1f);
+        float particleRadius = std::max(0.02f, 0.5f * fluidGPU->param_h);
+        Matrix4 scaleMat = MMath::scale(particleRadius, particleRadius, particleRadius);
         glUniformMatrix4fv(shader->GetUniformID("modelMatrix"), 1, GL_FALSE, scaleMat);
 
-        // 4. Draw fluid instances
-        mesh->RenderInstanced(GL_TRIANGLES, numInstances); // Only fluids!
+        size_t numInstances = fluidGPU->particles.size(); // fluids + ghosts, ghosts are discarded in frag
+        mesh->RenderInstanced(GL_TRIANGLES, numInstances);
     }
-   
+
     glUseProgram(0);
 }

--- a/ComponentFramework/Scene0p.cpp
+++ b/ComponentFramework/Scene0p.cpp
@@ -26,6 +26,28 @@ Scene0p::~Scene0p() {
     Debug::Info("Deleted Scene0: ", __FILE__, __LINE__);
 }
 
+
+static void MakeRotationMat3XYZ(float rxDeg, float ryDeg, float rzDeg, float outM[9]) {
+    const float rx = rxDeg * float(M_PI / 180.0);
+    const float ry = ryDeg * float(M_PI / 180.0);
+    const float rz = rzDeg * float(M_PI / 180.0);
+    const float cx = cosf(rx), sx = sinf(rx);
+    const float cy = cosf(ry), sy = sinf(ry);
+    const float cz = cosf(rz), sz = sinf(rz);
+    const float Rz[9] = { cz, sz, 0, -sz, cz, 0, 0, 0, 1 };
+    const float Ry[9] = { cy, 0, -sy, 0, 1, 0, sy, 0, cy };
+    const float Rx[9] = { 1, 0, 0, 0, cx, sx, 0, -sx, cx };
+    auto mul3 = [](const float A[9], const float B[9], float C[9]) {
+        for (int c = 0; c < 3; c++)
+            for (int r = 0; r < 3; r++)
+                C[c * 3 + r] = A[0 * 3 + r] * B[c * 3 + 0] + A[1 * 3 + r] * B[c * 3 + 1] + A[2 * 3 + r] * B[c * 3 + 2];
+        };
+    float Rzy[9]; mul3(Rz, Ry, Rzy);
+    mul3(Rzy, Rx, outM);
+}
+
+
+
 bool Scene0p::OnCreate() {
     Debug::Info("Loading assets Scene0: ", __FILE__, __LINE__);
 
@@ -61,8 +83,24 @@ bool Scene0p::OnCreate() {
     // Create fluid system (allocates SSBOs and compute pipelines)
     fluidGPU = new SPHFluidGPU(30000);
 
-    // Optional: enable legacy instancing fallback (useSSBO == 0)
-    // mesh->BindInstanceBuffer(fluidGPU->GetFluidVBO(), sizeof(float) * 4);
+    // One-time VAO setup for instancing: bind instance attribute 5 to fluid VBO, disable 4/6
+    mesh->BindInstanceBuffer(fluidGPU->GetFluidVBO(), static_cast<GLsizei>(sizeof(float) * 4));
+
+    lineShader = new Shader("shaders/lineVert.glsl", "shaders/lineFrag.glsl");
+    if (!lineShader->OnCreate()) {
+        std::cerr << "Line shader failed to load\n";
+        return false;
+    }
+    glGenVertexArrays(1, &boxVAO);
+    glBindVertexArray(boxVAO);
+    glGenBuffers(1, &boxVBO);
+    glBindBuffer(GL_ARRAY_BUFFER, boxVBO);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(float) * 3 * 24, nullptr, GL_DYNAMIC_DRAW); // 12 edges * 2 verts
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(float) * 3, (void*)0);
+    glBindVertexArray(0);
+
+    UpdateBoxWireframe();
 
     return true;
 }
@@ -87,6 +125,9 @@ void Scene0p::OnDestroy() {
     if (fluidGPU) {
         delete fluidGPU;
     }
+    if (boxVBO) glDeleteBuffers(1, &boxVBO);
+    if (boxVAO) glDeleteVertexArrays(1, &boxVAO);
+    if (lineShader) { lineShader->OnDestroy(); delete lineShader; }
 }
 
 void Scene0p::HandleEvents(const SDL_Event& sdlEvent) {
@@ -104,7 +145,47 @@ void Scene0p::HandleEvents(const SDL_Event& sdlEvent) {
         break;
     }
 }
+void Scene0p::UpdateBoxWireframe() {
+    if (!fluidGPU || !boxVBO) return;
 
+    const Vec3 C = fluidGPU->param_boxCenter;
+    const Vec3 H = fluidGPU->param_boxHalf;
+    float Rm[9]; MakeRotationMat3XYZ(fluidGPU->param_boxEulerDeg.x,
+        fluidGPU->param_boxEulerDeg.y,
+        fluidGPU->param_boxEulerDeg.z, Rm);
+    auto xform = [&](float x, float y, float z) -> Vec3 {
+        // rotate then translate
+        return Vec3(
+            Rm[0] * x + Rm[3] * y + Rm[6] * z + C.x,
+            Rm[1] * x + Rm[4] * y + Rm[7] * z + C.y,
+            Rm[2] * x + Rm[5] * y + Rm[8] * z + C.z
+        );
+        };
+
+    // 8 corners
+    Vec3 c[8];
+    int i = 0;
+    for (int sx = -1; sx <= 1; sx += 2)
+        for (int sy = -1; sy <= 1; sy += 2)
+            for (int sz = -1; sz <= 1; sz += 2)
+                c[i++] = xform(sx * H.x, sy * H.y, sz * H.z);
+
+    // edges (12) as pairs of indices into c[]
+    int E[24] = {
+        0,1, 0,2, 0,4,
+        3,1, 3,2, 3,7,
+        5,1, 5,4, 5,7,
+        6,2, 6,4, 6,7
+    };
+    float lines[24 * 3];
+    for (int e = 0; e < 24; ++e) {
+        Vec3 p = c[E[e]];
+        lines[e * 3 + 0] = p.x; lines[e * 3 + 1] = p.y; lines[e * 3 + 2] = p.z;
+    }
+    glBindBuffer(GL_ARRAY_BUFFER, boxVBO);
+    glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(lines), lines);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+}
 void Scene0p::Update(const float deltaTime) {
     ballAnimTime += deltaTime;
     float ballX = std::sin(ballAnimTime) * 3.0f;
@@ -196,6 +277,7 @@ void Scene0p::Update(const float deltaTime) {
         ImGui::Text("Performance");
         ImGui::Checkbox("Render from SSBO (fast)", &useSSBO);
         ImGui::Checkbox("Enable ghost boundaries (slower)", &fluidGPU->param_enableGhosts);
+        ImGui::Checkbox("Render from SSBO (fast)", &renderFromSSBO);
         ImGui::SameLine();
         ImGui::Checkbox("Enable grid sort (unused)", &fluidGPU->param_enableSort);
 
@@ -266,6 +348,9 @@ void Scene0p::Update(const float deltaTime) {
 
         ImGui::End();
 
+
+		UpdateBoxWireframe(); // in case box was changed
+
         if (pendingReset) {
             fluidGPU->ResetSimulation();
             fluidGPU->param_pause = false;
@@ -290,6 +375,20 @@ void Scene0p::Update(const float deltaTime) {
         if (pendingReset == false) {
             dtAccumulator += deltaTime;
         }
+
+
+        if (pendingReset) {
+            fluidGPU->ResetSimulation();
+            fluidGPU->param_pause = false;
+
+            // Rebind instance attribute 5 to the new fluid VBO
+            mesh->BindInstanceBuffer(fluidGPU->GetFluidVBO(), static_cast<GLsizei>(sizeof(float) * 4));
+
+            pendingReset = false;
+            // clear sim time accumulator to avoid large catch-up
+            dtAccumulator = 0.0f;
+        }
+
 
         int didSteps = 0;
         while (dtAccumulator >= fixedDt && didSteps < maxSubstepsPerFrame) {
@@ -319,25 +418,58 @@ void Scene0p::Render() const {
     if (drawInWireMode) glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
     else glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 
-    glUseProgram(shader->GetProgram());
-    glUniformMatrix4fv(shader->GetUniformID("projectionMatrix"), 1, GL_FALSE, projectionMatrix);
-    glUniformMatrix4fv(shader->GetUniformID("viewMatrix"), 1, GL_FALSE, viewMatrix);
+    // 1) Draw wireframe box
+    if (lineShader && boxVAO) {
+        glUseProgram(lineShader->GetProgram());
+        glUniformMatrix4fv(lineShader->GetUniformID("projectionMatrix"), 1, GL_FALSE, projectionMatrix);
+        glUniformMatrix4fv(lineShader->GetUniformID("viewMatrix"), 1, GL_FALSE, viewMatrix);
+        GLint colLoc = lineShader->GetUniformID("uColor");
+        if (colLoc != (GLint)-1) glUniform3f(colLoc, 0.85f, 0.95f, 1.0f);
+        glBindVertexArray(boxVAO);
+        glLineWidth(1.5f);
+        glDrawArrays(GL_LINES, 0, 24);
+        glBindVertexArray(0);
+        glUseProgram(0);
+    }
 
+    // 2) Draw particles (instanced)
     if (fluidGPU && mesh) {
-        // Ensure the SSBO used by the vertex shader is bound at binding=0
-        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, fluidGPU->ssbo);
+        // Make sure instance positions are fresh (copies pos from SSBO -> fluidVBO)
+        if (!renderFromSSBO) {
+            fluidGPU->UpdateFluidVBOFromGPU(); // only when using instance VBO
+        }
 
-        glUniform1i(shader->GetUniformID("useSSBO"), 1);
-        glUniform1i(shader->GetUniformID("colorMode"), 1); // Speed
-        glUniform2f(shader->GetUniformID("vizRange"), 0.0f, 10.0f);
+        glUseProgram(shader->GetProgram());
 
+        glUniformMatrix4fv(shader->GetUniformID("projectionMatrix"), 1, GL_FALSE, projectionMatrix);
+        glUniformMatrix4fv(shader->GetUniformID("viewMatrix"), 1, GL_FALSE, viewMatrix);
+
+        // Height band uniforms used by shader for height coloring
+        GLint hLoc = shader->GetUniformID("heightMinMax");
+        if (hLoc != -1) {
+            glUniform2f(hLoc,
+                fluidGPU->param_boxCenter.y - fluidGPU->param_boxHalf.y,
+                fluidGPU->param_boxCenter.y + fluidGPU->param_boxHalf.y);
+        }
+
+        // Visualization controls
+        if (GLint useLoc = shader->GetUniformID("useSSBO"); useLoc != -1)
+            glUniform1i(useLoc, renderFromSSBO ? 1 : 0);
+        GLint cmLoc = shader->GetUniformID("colorMode");
+        if (cmLoc != -1) glUniform1i(cmLoc, 1); // Speed
+        GLint vrLoc = shader->GetUniformID("vizRange");
+        if (vrLoc != -1) glUniform2f(vrLoc, 0.0f, 10.0f);
+
+        // Scale each sphere by particle radius
         float particleRadius = std::max(0.02f, 0.5f * fluidGPU->param_h);
         Matrix4 scaleMat = MMath::scale(particleRadius, particleRadius, particleRadius);
         glUniformMatrix4fv(shader->GetUniformID("modelMatrix"), 1, GL_FALSE, scaleMat);
 
-        size_t numInstances = fluidGPU->particles.size(); // fluids + ghosts, ghosts are discarded in frag
-        mesh->RenderInstanced(GL_TRIANGLES, numInstances);
-    }
+        // Bind particle SSBO for speed/pressure/density reads in VS
+        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, fluidGPU->ssbo);
+        mesh->RenderInstanced(GL_TRIANGLES, fluidGPU->GetNumFluids());
+    
 
-    glUseProgram(0);
+        glUseProgram(0);
+    }
 }

--- a/ComponentFramework/Scene0p.cpp
+++ b/ComponentFramework/Scene0p.cpp
@@ -1,475 +1,196 @@
-﻿#include <iostream>
-#include <SDL.h>
-#include "Scene0p.h"
-#include <MMath.h>
+﻿#include "Scene0p.h"
 #include "Debug.h"
-#include "Mesh.h"
-#include "Shader.h"
-#include "Body.h"
-#include <cmath>
-#include "SPHFluid3D.h"
-#include "imgui.h"
-#include "imgui_impl_sdl2.h"
-#include "SceneManager.h"
-#include <limits>
-#include <algorithm>
+#include <cstring>
 
-Scene0p::Scene0p() :
-    sphere{ nullptr }, shader{ nullptr }, mesh{ nullptr },
-    drawInWireMode{ true }, mouseX{ 0 }, mouseY{ 0 }, mouseDown{ false }, ballAnimTime{ 0.0f },
-    fluidGPU{ nullptr }
-{
-    Debug::Info("Created Scene0: ", __FILE__, __LINE__);
-}
+using namespace MATH;
 
-Scene0p::~Scene0p() {
-    Debug::Info("Deleted Scene0: ", __FILE__, __LINE__);
-}
+Scene0p::Scene0p() {}
+Scene0p::~Scene0p() {}
 
-
-static void MakeRotationMat3XYZ(float rxDeg, float ryDeg, float rzDeg, float outM[9]) {
-    const float rx = rxDeg * float(M_PI / 180.0);
-    const float ry = ryDeg * float(M_PI / 180.0);
-    const float rz = rzDeg * float(M_PI / 180.0);
-    const float cx = cosf(rx), sx = sinf(rx);
-    const float cy = cosf(ry), sy = sinf(ry);
-    const float cz = cosf(rz), sz = sinf(rz);
-    const float Rz[9] = { cz, sz, 0, -sz, cz, 0, 0, 0, 1 };
-    const float Ry[9] = { cy, 0, -sy, 0, 1, 0, sy, 0, cy };
-    const float Rx[9] = { 1, 0, 0, 0, cx, sx, 0, -sx, cx };
-    auto mul3 = [](const float A[9], const float B[9], float C[9]) {
-        for (int c = 0; c < 3; c++)
-            for (int r = 0; r < 3; r++)
-                C[c * 3 + r] = A[0 * 3 + r] * B[c * 3 + 0] + A[1 * 3 + r] * B[c * 3 + 1] + A[2 * 3 + r] * B[c * 3 + 2];
-        };
-    float Rzy[9]; mul3(Rz, Ry, Rzy);
-    mul3(Rzy, Rx, outM);
-}
-
-
-
-bool Scene0p::OnCreate() {
-    Debug::Info("Loading assets Scene0: ", __FILE__, __LINE__);
-
-    sphere = new Body();
-    sphere->OnCreate();
-    sphere->SetPosition(Vec3(0.0f, -20.0f, 0.0f));
-
-    mesh = new Mesh("meshes/Sphere.obj");
-    mesh->OnCreate();
-
-    shader = new Shader("shaders/defaultVert.glsl", "shaders/defaultFrag.glsl");
-    if (!shader->OnCreate()) {
-        std::cerr << "Shader failed to load\n";
-        return false;
-    }
-
-    // Ensure the shader storage block used by the vertex shader is bound to binding = 0
-    {
-        GLuint prog = shader->GetProgram();
-        GLuint block = glGetProgramResourceIndex(prog, GL_SHADER_STORAGE_BLOCK, "ParticleBuf");
-        if (block != GL_INVALID_INDEX) {
-            glShaderStorageBlockBinding(prog, block, 0);
-        }
-        else {
-            std::cerr << "SSBO block 'ParticleBuf' not found in program\n";
-        }
-    }
-
-    projectionMatrix = MMath::perspective(45.0f, 16.0f / 9.0f, 0.5f, 100.0f);
-    viewMatrix = MMath::lookAt(cameraPos, cameraTarget, cameraUp);
-    modelMatrix.loadIdentity();
-
-    // Create fluid system (allocates SSBOs and compute pipelines)
-    fluidGPU = new SPHFluidGPU(30000);
-
-    // One-time VAO setup for instancing: bind instance attribute 5 to fluid VBO, disable 4/6
-    mesh->BindInstanceBuffer(fluidGPU->GetFluidVBO(), static_cast<GLsizei>(sizeof(float) * 4));
-
-    lineShader = new Shader("shaders/lineVert.glsl", "shaders/lineFrag.glsl");
-    if (!lineShader->OnCreate()) {
-        std::cerr << "Line shader failed to load\n";
-        return false;
-    }
-    glGenVertexArrays(1, &boxVAO);
-    glBindVertexArray(boxVAO);
-    glGenBuffers(1, &boxVBO);
-    glBindBuffer(GL_ARRAY_BUFFER, boxVBO);
-    glBufferData(GL_ARRAY_BUFFER, sizeof(float) * 3 * 24, nullptr, GL_DYNAMIC_DRAW); // 12 edges * 2 verts
+void Scene0p::BoxWire::init() {
+    if (vao) return;
+    const float v[] = {
+        // bottom square
+        -1,-1,-1,  1,-1,-1,   1,-1,-1,  1,-1, 1,
+         1,-1, 1, -1,-1, 1,  -1,-1, 1, -1,-1,-1,
+         // top square
+         -1, 1,-1,  1, 1,-1,   1, 1,-1,  1, 1, 1,
+          1, 1, 1, -1, 1, 1,  -1, 1, 1, -1, 1,-1,
+          // verticals
+          -1,-1,-1, -1, 1,-1,   1,-1,-1,  1, 1,-1,
+           1,-1, 1,  1, 1, 1,  -1,-1, 1, -1, 1, 1
+    };
+    glGenVertexArrays(1, &vao);
+    glGenBuffers(1, &vbo);
+    glBindVertexArray(vao);
+    glBindBuffer(GL_ARRAY_BUFFER, vbo);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(v), v, GL_STATIC_DRAW);
     glEnableVertexAttribArray(0);
     glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(float) * 3, (void*)0);
     glBindVertexArray(0);
+}
+void Scene0p::BoxWire::draw(Shader& lineShader, const Matrix4& P, const Matrix4& V,
+    const Matrix4& M, const Vec3& color) {
+    glUseProgram(lineShader.GetProgram());
+    glUniformMatrix4fv(lineShader.GetUniformID("projectionMatrix"), 1, GL_FALSE, P);
+    glUniformMatrix4fv(lineShader.GetUniformID("viewMatrix"), 1, GL_FALSE, V);
+    glUniformMatrix4fv(lineShader.GetUniformID("modelMatrix"), 1, GL_FALSE, M);
+    GLint lc = glGetUniformLocation(lineShader.GetProgram(), "lineColor");
+    if (lc >= 0) glUniform3f(lc, color.x, color.y, color.z);
+    glBindVertexArray(vao);
+    glDrawArrays(GL_LINES, 0, 24);
+    glBindVertexArray(0);
+    glUseProgram(0);
+}
+void Scene0p::BoxWire::destroy() {
+    if (vbo) { glDeleteBuffers(1, &vbo); vbo = 0; }
+    if (vao) { glDeleteVertexArrays(1, &vao); vao = 0; }
+}
 
-    UpdateBoxWireframe();
+bool Scene0p::OnCreate() {
+    Debug::Info("Scene0p OnCreate", __FILE__, __LINE__);
+
+    // Camera
+    projectionMatrix = MMath::perspective(45.0f, 16.0f / 9.0f, 0.2f, 200.0f);
+    viewMatrix = MMath::lookAt(Vec3(0, 0, 18), Vec3(0, 0, 0), Vec3(0, 1, 0));
+    modelMatrix.loadIdentity();
+
+    // Fluid
+    fluidGPU = new SPHFluidGPU(30000); // choose your N
+    // (Grid build & SPH uniforms in DispatchCompute() match your existing codepath) :contentReference[oaicite:3]{index=3}
+
+    // Shaders
+    impostorShader = new Shader("shaders/particleImpostor.vert", "shaders/particleImpostor.frag");
+    if (!impostorShader->OnCreate()) { Debug::FatalError("Impostor shader create failed", __FILE__, __LINE__); }
+
+    lineShader = new Shader("shaders/lineVert.glsl", "shaders/lineFrag.glsl");
+    if (!lineShader->OnCreate()) { Debug::FatalError("Line shader create failed", __FILE__, __LINE__); }
+
+    // GPU state
+    glEnable(GL_DEPTH_TEST);
+    glEnable(GL_CULL_FACE);
+    glEnable(GL_PROGRAM_POINT_SIZE);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA); // nice for impostors (enable/disable as you like)
+
+    // Geometry for impostors and wireframe
+    SetupImpostorVAO();
+    boxWire.init();
+    UpdateBoxWireframe();   // build once
+    lastBoxCenter = fluidGPU->param_boxCenter;
+    lastBoxHalf = fluidGPU->param_boxHalf;
+    lastBoxEuler = fluidGPU->param_boxEulerDeg;
 
     return true;
 }
 
 void Scene0p::OnDestroy() {
-    Debug::Info("Deleting assets Scene0: ", __FILE__, __LINE__);
-    if (sphere) {
-        sphere->OnDestroy();
-        delete sphere;
-    }
-
-    if (mesh) {
-        mesh->OnDestroy();
-        delete mesh;
-    }
-
-    if (shader) {
-        shader->OnDestroy();
-        delete shader;
-    }
-
-    if (fluidGPU) {
-        delete fluidGPU;
-    }
-    if (boxVBO) glDeleteBuffers(1, &boxVBO);
-    if (boxVAO) glDeleteVertexArrays(1, &boxVAO);
-    if (lineShader) { lineShader->OnDestroy(); delete lineShader; }
+    boxWire.destroy();
+    if (impostorVAO) { glDeleteVertexArrays(1, &impostorVAO); impostorVAO = 0; }
+    if (lineShader) { lineShader->OnDestroy(); delete lineShader; lineShader = nullptr; }
+    if (impostorShader) { impostorShader->OnDestroy(); delete impostorShader; impostorShader = nullptr; }
+    if (fluidGPU) { delete fluidGPU; fluidGPU = nullptr; }
 }
 
-void Scene0p::HandleEvents(const SDL_Event& sdlEvent) {
-    switch (sdlEvent.type) {
-    case SDL_KEYDOWN:
-        switch (sdlEvent.key.keysym.scancode) {
-        case SDL_SCANCODE_W: cameraPos.y += 0.2f; break;
-        case SDL_SCANCODE_S: cameraPos.y -= 0.2f; break;
-        case SDL_SCANCODE_A: cameraPos.x -= 0.2f; break;
-        case SDL_SCANCODE_D: cameraPos.x += 0.2f; break;
-        case SDL_SCANCODE_R: cameraPos.z += 0.2f; break;
-        case SDL_SCANCODE_E: cameraPos.z -= 0.2f; break;
-        case SDL_SCANCODE_Z: drawInWireMode = !drawInWireMode; break;
-        }
-        break;
-    }
-}
-void Scene0p::UpdateBoxWireframe() {
-    if (!fluidGPU || !boxVBO) return;
-
-    const Vec3 C = fluidGPU->param_boxCenter;
-    const Vec3 H = fluidGPU->param_boxHalf;
-    float Rm[9]; MakeRotationMat3XYZ(fluidGPU->param_boxEulerDeg.x,
-        fluidGPU->param_boxEulerDeg.y,
-        fluidGPU->param_boxEulerDeg.z, Rm);
-    auto xform = [&](float x, float y, float z) -> Vec3 {
-        // rotate then translate
-        return Vec3(
-            Rm[0] * x + Rm[3] * y + Rm[6] * z + C.x,
-            Rm[1] * x + Rm[4] * y + Rm[7] * z + C.y,
-            Rm[2] * x + Rm[5] * y + Rm[8] * z + C.z
-        );
-        };
-
-    // 8 corners
-    Vec3 c[8];
-    int i = 0;
-    for (int sx = -1; sx <= 1; sx += 2)
-        for (int sy = -1; sy <= 1; sy += 2)
-            for (int sz = -1; sz <= 1; sz += 2)
-                c[i++] = xform(sx * H.x, sy * H.y, sz * H.z);
-
-    // edges (12) as pairs of indices into c[]
-    int E[24] = {
-        0,1, 0,2, 0,4,
-        3,1, 3,2, 3,7,
-        5,1, 5,4, 5,7,
-        6,2, 6,4, 6,7
-    };
-    float lines[24 * 3];
-    for (int e = 0; e < 24; ++e) {
-        Vec3 p = c[E[e]];
-        lines[e * 3 + 0] = p.x; lines[e * 3 + 1] = p.y; lines[e * 3 + 2] = p.z;
-    }
-    glBindBuffer(GL_ARRAY_BUFFER, boxVBO);
-    glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(lines), lines);
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
-}
-void Scene0p::Update(const float deltaTime) {
-    ballAnimTime += deltaTime;
-    float ballX = std::sin(ballAnimTime) * 3.0f;
-    if (sphere) { sphere->SetPosition(Vec3(ballX, 0.0f, 0.0f)); }
-    viewMatrix = MMath::lookAt(cameraPos, cameraTarget, cameraUp);
-
-    if (fluidGPU) {
-        ImGui::Begin("Fluid Controls");
-        ImGui::Text("FPS: %.1f", ImGui::GetIO().Framerate);
-        ImGui::Text("Particles: %zu (fluids: %zu)", fluidGPU->particles.size(), fluidGPU->GetNumFluids());
-        ImGui::Separator();
-
-        if (ImGui::Button("Preset: Stable Water")) {
-            fluidGPU->param_pause = false;
-            fluidGPU->param_h = 0.28f;
-            fluidGPU->param_restDensity = 1000.0f;
-            fluidGPU->param_gasConstant = 2000.0f;
-            fluidGPU->param_viscosity = 3.5f;
-            fluidGPU->param_gravityY = -980.0f;     // cm/s^2 (was -9.81f)
-            fluidGPU->param_surfaceTension = 0.0f;
-            fluidGPU->param_timeStep = 1.0e-3f;     // was 2e-4f (too small)
-            pendingReset = true;                    // ensure buffers rebuilt when h or layout changes
-        }
-
-        if (ImGui::Button("Preset: Splashy Water")) {
-            fluidGPU->param_pause = false;
-            fluidGPU->param_h = 0.22f;
-            fluidGPU->param_restDensity = 1000.0f;
-            fluidGPU->param_gasConstant = 6000.0f;
-            fluidGPU->param_viscosity = 1.2f;
-            fluidGPU->param_gravityY = -980.0f;        // cm/s^2 (was -9.81f)
-            fluidGPU->param_surfaceTension = 0.12f;
-            fluidGPU->param_timeStep = 5.0e-4f;        // was 1e-4f
-            fluidGPU->param_useJitter = true;
-            fluidGPU->param_jitterAmp = 0.06f;
-
-            fluidGPU->param_wallRestitution = 0.05f;
-            fluidGPU->param_wallFriction = 0.05f;
-
-            pendingReset = true;
-        }
-        ImGui::SameLine();
-        if (ImGui::Button("Fit Camera")) {
-            Vec3 minV(std::numeric_limits<float>::max(),
-                std::numeric_limits<float>::max(),
-                std::numeric_limits<float>::max());
-            Vec3 maxV(-std::numeric_limits<float>::max(),
-                -std::numeric_limits<float>::max(),
-                -std::numeric_limits<float>::max());
-            size_t count = 0;
-            for (const auto& p : fluidGPU->particles) {
-                if (p.isGhost) continue;
-                minV.x = std::min(minV.x, p.pos.x);
-                minV.y = std::min(minV.y, p.pos.y);
-                minV.z = std::min(minV.z, p.pos.z);
-                maxV.x = std::max(maxV.x, p.pos.x);
-                maxV.y = std::max(maxV.y, p.pos.y);
-                maxV.z = std::max(maxV.z, p.pos.z);
-                ++count;
-            }
-            if (count > 0) {
-                Vec3 center((minV.x + maxV.x) * 0.5f,
-                    (minV.y + maxV.y) * 0.5f,
-                    (minV.z + maxV.z) * 0.5f);
-                float height = (maxV.y - minV.y);
-                float width = (maxV.x - minV.x);
-                const float fovY = 45.0f * (3.14159265359f / 180.0f);
-                float halfH = std::max(height, width) * 0.5f;
-                float dist = halfH / std::tan(fovY * 0.5f) * 1.35f;
-                cameraTarget = center;
-                cameraPos = Vec3(center.x, center.y, center.z + dist);
-            }
-        }
-
-        // Sim params
-        ImGui::Checkbox("Pause simulation", &fluidGPU->param_pause);
-        ImGui::SliderFloat("h (smoothing)", &fluidGPU->param_h, 0.10f, 1.00f);
-        ImGui::SliderFloat("mass", &fluidGPU->param_mass, 1.0f, 50.0f);
-        ImGui::SliderFloat("restDensity", &fluidGPU->param_restDensity, 100.0f, 2000.0f);
-        ImGui::SliderFloat("gasConstant", &fluidGPU->param_gasConstant, 100.0f, 30000.0f);
-        ImGui::SliderFloat("viscosity", &fluidGPU->param_viscosity, 0.0f, 20.0f);
-        ImGui::SliderFloat("gravityY", &fluidGPU->param_gravityY, -5000.0f, 0.0f);
-        ImGui::SliderFloat("surfaceTension", &fluidGPU->param_surfaceTension, 0.0f, 1.0f);
-        ImGui::SliderFloat("timeStep", &fluidGPU->param_timeStep, 1e-5f, 5e-3f, "%.6f", ImGuiSliderFlags_Logarithmic);
-
-        // Performance toggles
-        static bool useSSBO = true; // fast path (render)
-        ImGui::Separator();
-        ImGui::Text("Performance");
-        ImGui::Checkbox("Render from SSBO (fast)", &useSSBO);
-        ImGui::Checkbox("Enable ghost boundaries (slower)", &fluidGPU->param_enableGhosts);
-        ImGui::Checkbox("Render from SSBO (fast)", &renderFromSSBO);
-        ImGui::SameLine();
-        ImGui::Checkbox("Enable grid sort (unused)", &fluidGPU->param_enableSort);
-
-        // Box transform (move/resize/rotate)
-        ImGui::Separator();
-        ImGui::Text("Box Transform (OBB)");
-        ImGui::DragFloat3("Center", &fluidGPU->param_boxCenter.x, 0.05f);
-        ImGui::DragFloat3("Half Extents", &fluidGPU->param_boxHalf.x, 0.05f, 0.05f, 100.0f);
-        ImGui::DragFloat3("Euler XYZ (deg)", &fluidGPU->param_boxEulerDeg.x, 0.5f, -180.0f, 180.0f);
-        ImGui::SliderFloat("Wall Restitution", &fluidGPU->param_wallRestitution, 0.0f, 1.0f);
-        ImGui::SliderFloat("Wall Friction", &fluidGPU->param_wallFriction, 0.0f, 1.0f);
-        if (ImGui::Button("Rebuild Grid for Box")) {
-            fluidGPU->RecreateGridForBox();
-
-        }
-
-        // Spawn layout
-        ImGui::Separator();
-        ImGui::Text("Spawn Layout");
-        ImGui::Checkbox("Use jitter", &fluidGPU->param_useJitter);
-        ImGui::SameLine();
-        ImGui::SliderFloat("Jitter amp * spacing", &fluidGPU->param_jitterAmp, 0.0f, 0.5f, "%.2f");
-        ImGui::SameLine();
-        if (ImGui::Button("Rebuild Layout")) {
-            pendingReset = true;
-
-        }
-
-        // Waves
-        ImGui::Separator();
-        ImGui::Text("Waves");
-        static float waveAmplitude = 1.5f;
-        static float waveWavelength = 3.0f;
-        static float wavePhaseSpeed = 4.0f;
-        static int waveDirIdx = 1;
-        static float yBandMin = -std::numeric_limits<float>::infinity();
-        static float yBandMax = std::numeric_limits<float>::infinity();
-        static bool continuousWave = false;
-        static float wavePhase = 0.0f;
-
-        ImGui::SliderFloat("Amplitude", &waveAmplitude, 0.0f, 25.0f);
-        ImGui::SliderFloat("Wavelength", &waveWavelength, 0.5f, 10.0f);
-        ImGui::SliderFloat("Phase speed", &wavePhaseSpeed, 0.0f, 20.0f);
-        ImGui::RadioButton("Dir X", &waveDirIdx, 0); ImGui::SameLine();
-        ImGui::RadioButton("Dir Y", &waveDirIdx, 1); ImGui::SameLine();
-        ImGui::RadioButton("Dir Z", &waveDirIdx, 2);
-        ImGui::InputFloat("Band Y min", &yBandMin);
-        ImGui::InputFloat("Band Y max", &yBandMax);
-        ImGui::Checkbox("Continuous wave (CPU sync)", &continuousWave);
-        if (ImGui::Button("Impulse Now")) {
-            Vec3 dir = (waveDirIdx == 0) ? Vec3(1, 0, 0) : (waveDirIdx == 1) ? Vec3(0, 1, 0) : Vec3(0, 0, 1);
-            fluidGPU->ApplyWaveImpulse(waveAmplitude, waveWavelength, wavePhase, dir, yBandMin, yBandMax);
-        }
-        ImGui::SameLine();
-        if (ImGui::Button("Reset Simulation")) {
-            pendingReset = true;
-        }
-
-        // Visualization
-        ImGui::Separator();
-        ImGui::Text("Visualization");
-        static int vizMode = 1;
-        static float rangeMin = 0.0f, rangeMax = 10.0f;
-        ImGui::Combo("Color by", &vizMode, "Depth\0Speed\0Pressure\0Density\0\0");
-        ImGui::DragFloat("Range Min", &rangeMin, 0.1f);
-        ImGui::DragFloat("Range Max", &rangeMax, 0.1f);
-        ImGui::TextDisabled("Tip: SSBO mode avoids CPU readbacks and boosts FPS.");
-
-        ImGui::End();
-
-
-		UpdateBoxWireframe(); // in case box was changed
-
-        if (pendingReset) {
-            fluidGPU->ResetSimulation();
-            fluidGPU->param_pause = false;
-            pendingReset = false;
-            // clear sim time accumulator to avoid large catch-up
-            dtAccumulator = 0.0f;
-        }
-
-        if (continuousWave) {
-            wavePhase += wavePhaseSpeed * deltaTime;
-            Vec3 dir = (waveDirIdx == 0) ? Vec3(1, 0, 0) : (waveDirIdx == 1) ? Vec3(0, 1, 0) : Vec3(0, 0, 1);
-            fluidGPU->ApplyWaveImpulse(waveAmplitude, waveWavelength, wavePhase, dir, yBandMin, yBandMax);
-        }
-
-        // Sim step
-       // Sim step (fixed step accumulator; never exceed param_timeStep)
-        static float dtAccumulator = 0.0f;
-        const float fixedDt = std::max(1e-6f, fluidGPU->param_timeStep);
-        const int maxSubstepsPerFrame = 64; // cap to avoid long frames
-
-        // If we just reset, drop leftovers to avoid a huge burst
-        if (pendingReset == false) {
-            dtAccumulator += deltaTime;
-        }
-
-
-        if (pendingReset) {
-            fluidGPU->ResetSimulation();
-            fluidGPU->param_pause = false;
-
-            // Rebind instance attribute 5 to the new fluid VBO
-            mesh->BindInstanceBuffer(fluidGPU->GetFluidVBO(), static_cast<GLsizei>(sizeof(float) * 4));
-
-            pendingReset = false;
-            // clear sim time accumulator to avoid large catch-up
-            dtAccumulator = 0.0f;
-        }
-
-
-        int didSteps = 0;
-        while (dtAccumulator >= fixedDt && didSteps < maxSubstepsPerFrame) {
-            fluidGPU->DispatchCompute(fixedDt);
-            dtAccumulator -= fixedDt;
-            ++didSteps;
-        }
-
-        // Optional: if we hit the cap, discard excess to prevent spiral-of-death
-        if (didSteps == maxSubstepsPerFrame && dtAccumulator > fixedDt) {
-            dtAccumulator = fmodf(dtAccumulator, fixedDt);
-        }
-
-        // Show what happened this frame
-        ImGui::Text("Substeps: %d  dt: %.6f  accum: %.6f", didSteps, fixedDt, dtAccumulator);
-
-        if (!useSSBO) {
-            fluidGPU->UpdateFluidVBOFromGPU();
+void Scene0p::HandleEvents(const SDL_Event& e) {
+    if (e.type == SDL_KEYDOWN) {
+        switch (e.key.keysym.scancode) {
+        case SDL_SCANCODE_SPACE: // quick splash on space as a demo
+            fluidGPU->ApplyWaveImpulseGPU(2.0f, 3.5f, SDL_GetTicks() * 0.002f, Vec3(0, 1, 0), -1.0f, 2.0f);
+            break;
         }
     }
 }
 
-void Scene0p::Render() const {
-    glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+void Scene0p::Update(float deltaTime) {
+    // Single member dtAccumulator; no duplicate toggle
+    // Tiny adaptive substep cap: if frame slow, reduce to 8 else 16
+    maxSubstepsPerFrame = (deltaTime > (1.0f / 50.0f)) ? 8 : 16;
+
+    dtAccumulator += deltaTime;
+    int did = 0;
+    while (dtAccumulator >= fixedDt && did < maxSubstepsPerFrame) {
+        fluidGPU->DispatchCompute();      // grid -> SPH -> OBB, minimal barriers
+        dtAccumulator -= fixedDt;
+        ++did;
+    }
+    // clamp runaway
+    if (dtAccumulator > fixedDt * 4.0f) dtAccumulator = fixedDt * 4.0f;
+
+    // If box params changed (maybe via UI), rebuild wireframe once
+    const Vec3 c = fluidGPU->param_boxCenter;
+    const Vec3 h = fluidGPU->param_boxHalf;
+    const Vec3 e = fluidGPU->param_boxEulerDeg;
+    if (c.x != lastBoxCenter.x || c.y != lastBoxCenter.y || c.z != lastBoxCenter.z ||
+        h.x != lastBoxHalf.x || h.y != lastBoxHalf.y || h.z != lastBoxHalf.z ||
+        e.x != lastBoxEuler.x || e.y != lastBoxEuler.y || e.z != lastBoxEuler.z) {
+        UpdateBoxWireframe();
+        lastBoxCenter = c; lastBoxHalf = h; lastBoxEuler = e;
+    }
+}
+
+void Scene0p::Render() {
+    glClearColor(0, 0, 0, 1);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-    if (drawInWireMode) glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
-    else glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+    // Particles (impostors)
+    DrawFluidImpostors();
 
-    // 1) Draw wireframe box
-    if (lineShader && boxVAO) {
-        glUseProgram(lineShader->GetProgram());
-        glUniformMatrix4fv(lineShader->GetUniformID("projectionMatrix"), 1, GL_FALSE, projectionMatrix);
-        glUniformMatrix4fv(lineShader->GetUniformID("viewMatrix"), 1, GL_FALSE, viewMatrix);
-        GLint colLoc = lineShader->GetUniformID("uColor");
-        if (colLoc != (GLint)-1) glUniform3f(colLoc, 0.85f, 0.95f, 1.0f);
-        glBindVertexArray(boxVAO);
-        glLineWidth(1.5f);
-        glDrawArrays(GL_LINES, 0, 24);
-        glBindVertexArray(0);
-        glUseProgram(0);
+    // Box outline
+    Matrix4 Mbox = MMath::translate(fluidGPU->param_boxCenter) *
+        MMath::scale(fluidGPU->param_boxHalf);
+    boxWire.draw(*lineShader, projectionMatrix, viewMatrix, Mbox, Vec3(0.9f, 0.9f, 0.9f));
+}
+
+void Scene0p::SetupImpostorVAO() {
+    if (impostorVAO) return;
+    glGenVertexArrays(1, &impostorVAO);
+    glBindVertexArray(impostorVAO);
+
+    // per-instance position from fluid VBO (vec4)
+    glBindBuffer(GL_ARRAY_BUFFER, fluidGPU->GetFluidVBO());
+    glEnableVertexAttribArray(5);
+    glVertexAttribPointer(5, 4, GL_FLOAT, GL_FALSE, sizeof(float) * 4, (void*)0);
+    glVertexAttribDivisor(5, 1);
+
+    glBindVertexArray(0);
+}
+
+int Scene0p::CurrentViewportHeight() const {
+    GLint vp[4]; glGetIntegerv(GL_VIEWPORT, vp);
+    return vp[3] > 0 ? vp[3] : 1080;
+}
+
+void Scene0p::DrawFluidImpostors() {
+    // refresh instance positions (maps SSBO -> VBO for fluids only)
+    if (renderFromSSBO) {
+        fluidGPU->UpdateFluidVBOFromGPU();  // keeps draw path simple/fast  :contentReference[oaicite:4]{index=4}
     }
 
-    // 2) Draw particles (instanced)
-    if (fluidGPU && mesh) {
-        // Make sure instance positions are fresh (copies pos from SSBO -> fluidVBO)
-        if (!renderFromSSBO) {
-            fluidGPU->UpdateFluidVBOFromGPU(); // only when using instance VBO
-        }
+    glUseProgram(impostorShader->GetProgram());
+    glUniformMatrix4fv(impostorShader->GetUniformID("projectionMatrix"), 1, GL_FALSE, projectionMatrix);
+    glUniformMatrix4fv(impostorShader->GetUniformID("viewMatrix"), 1, GL_FALSE, viewMatrix);
+    glUniformMatrix4fv(impostorShader->GetUniformID("modelMatrix"), 1, GL_FALSE, modelMatrix);
 
-        glUseProgram(shader->GetProgram());
+    // Heat-map: speed in [0..150] by default
+    glUniform1i(glGetUniformLocation(impostorShader->GetProgram(), "colorMode"), 1);
+    glUniform2f(glGetUniformLocation(impostorShader->GetProgram(), "vizRange"), 0.0f, 150.0f);
 
-        glUniformMatrix4fv(shader->GetUniformID("projectionMatrix"), 1, GL_FALSE, projectionMatrix);
-        glUniformMatrix4fv(shader->GetUniformID("viewMatrix"), 1, GL_FALSE, viewMatrix);
+    // Point size based on world radius + viewport height
+    glUniform1f(glGetUniformLocation(impostorShader->GetProgram(), "particleRadius"), 0.08f);
+    glUniform1f(glGetUniformLocation(impostorShader->GetProgram(), "viewportHeight"), (float)CurrentViewportHeight());
 
-        // Height band uniforms used by shader for height coloring
-        GLint hLoc = shader->GetUniformID("heightMinMax");
-        if (hLoc != -1) {
-            glUniform2f(hLoc,
-                fluidGPU->param_boxCenter.y - fluidGPU->param_boxHalf.y,
-                fluidGPU->param_boxCenter.y + fluidGPU->param_boxHalf.y);
-        }
+    // Bind particle SSBO for the vertex shader (heat-map fetch)
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, fluidGPU->ssbo); // graphics path needs its own bind  :contentReference[oaicite:5]{index=5}
 
-        // Visualization controls
-        if (GLint useLoc = shader->GetUniformID("useSSBO"); useLoc != -1)
-            glUniform1i(useLoc, renderFromSSBO ? 1 : 0);
-        GLint cmLoc = shader->GetUniformID("colorMode");
-        if (cmLoc != -1) glUniform1i(cmLoc, 1); // Speed
-        GLint vrLoc = shader->GetUniformID("vizRange");
-        if (vrLoc != -1) glUniform2f(vrLoc, 0.0f, 10.0f);
+    glBindVertexArray(impostorVAO);
+    glDrawArraysInstanced(GL_POINTS, 0, 1, (GLsizei)fluidGPU->GetNumFluids());
+    glBindVertexArray(0);
 
-        // Scale each sphere by particle radius
-        float particleRadius = std::max(0.02f, 0.5f * fluidGPU->param_h);
-        Matrix4 scaleMat = MMath::scale(particleRadius, particleRadius, particleRadius);
-        glUniformMatrix4fv(shader->GetUniformID("modelMatrix"), 1, GL_FALSE, scaleMat);
+    glUseProgram(0);
+}
 
-        // Bind particle SSBO for speed/pressure/density reads in VS
-        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, fluidGPU->ssbo);
-        mesh->RenderInstanced(GL_TRIANGLES, fluidGPU->GetNumFluids());
-    
-
-        glUseProgram(0);
-    }
+void Scene0p::UpdateBoxWireframe() {
+    // nothing to rebuild here except you may update a cached buffer;
+    // BoxWire uses unit cube and we scale/translate via model matrix in draw().
+    // Left as hook if you later prebake a rotated OBB frame.
 }

--- a/ComponentFramework/Scene0p.cpp
+++ b/ComponentFramework/Scene0p.cpp
@@ -1,81 +1,92 @@
-﻿#include "Scene0p.h"
-#include "Debug.h"
-#include <cstring>
+﻿#include <iostream>
+#include <limits>
+#include <algorithm>
+#include <cmath>
+#include <SDL.h>
+#include <MMath.h>
 
-using namespace MATH;
+#include "Scene0p.h"
+#include "Debug.h"
+#include "Mesh.h"
+#include "Body.h"
+#include "imgui.h"
+#include "imgui_impl_sdl2.h"
+#include "SceneManager.h"
+#include "SPHFluid3D.h"
+
+using MATH::MMath;
+
+static void MakeRotationMat3XYZ(float rxDeg, float ryDeg, float rzDeg, float outM[9]) {
+    const float rx = rxDeg * float(M_PI / 180.0);
+    const float ry = ryDeg * float(M_PI / 180.0);
+    const float rz = rzDeg * float(M_PI / 180.0);
+    const float cx = cosf(rx), sx = sinf(rx);
+    const float cy = cosf(ry), sy = sinf(ry);
+    const float cz = cosf(rz), sz = sinf(rz);
+    const float Rz[9] = { cz, sz, 0, -sz, cz, 0, 0, 0, 1 };
+    const float Ry[9] = { cy, 0, -sy, 0, 1, 0, sy, 0, cy };
+    const float Rx[9] = { 1, 0, 0, 0, cx, sx, 0, -sx, cx };
+    auto mul3 = [](const float A[9], const float B[9], float C[9]) {
+        for (int c = 0; c < 3; ++c)
+            for (int r = 0; r < 3; ++r)
+                C[c * 3 + r] = A[0 * 3 + r] * B[c * 3 + 0] + A[1 * 3 + r] * B[c * 3 + 1] + A[2 * 3 + r] * B[c * 3 + 2];
+        };
+    float Rzy[9]; mul3(Rz, Ry, Rzy);
+    mul3(Rzy, Rx, outM);
+}
 
 Scene0p::Scene0p() {}
 Scene0p::~Scene0p() {}
 
-void Scene0p::BoxWire::init() {
-    if (vao) return;
-    const float v[] = {
-        // bottom square
-        -1,-1,-1,  1,-1,-1,   1,-1,-1,  1,-1, 1,
-         1,-1, 1, -1,-1, 1,  -1,-1, 1, -1,-1,-1,
-         // top square
-         -1, 1,-1,  1, 1,-1,   1, 1,-1,  1, 1, 1,
-          1, 1, 1, -1, 1, 1,  -1, 1, 1, -1, 1,-1,
-          // verticals
-          -1,-1,-1, -1, 1,-1,   1,-1,-1,  1, 1,-1,
-           1,-1, 1,  1, 1, 1,  -1,-1, 1, -1, 1, 1
-    };
-    glGenVertexArrays(1, &vao);
-    glGenBuffers(1, &vbo);
-    glBindVertexArray(vao);
-    glBindBuffer(GL_ARRAY_BUFFER, vbo);
-    glBufferData(GL_ARRAY_BUFFER, sizeof(v), v, GL_STATIC_DRAW);
+bool Scene0p::OnCreate() {
+    Debug::Info("Loading assets Scene0p", __FILE__, __LINE__);
+
+    sphere = new Body(); sphere->OnCreate();
+    sphere->SetPosition(Vec3(0.0f, -20.0f, 0.0f));
+
+    mesh = new Mesh("meshes/Sphere.obj"); mesh->OnCreate();
+
+    // Instanced sphere shader (your original)
+    shader = new Shader("shaders/defaultVert.glsl", "shaders/defaultFrag.glsl");
+    if (!shader->OnCreate()) { std::cerr << "default shader failed\n"; return false; }
+
+    // Make sure SSBO block is at binding=0 for vertex fetch
+    {
+        GLuint prog = shader->GetProgram();
+        GLuint block = glGetProgramResourceIndex(prog, GL_SHADER_STORAGE_BLOCK, "ParticleBuf");
+        if (block != GL_INVALID_INDEX) glShaderStorageBlockBinding(prog, block, 0);
+        else std::cerr << "SSBO block 'ParticleBuf' not found in program\n";
+    }
+
+    projectionMatrix = MMath::perspective(45.0f, 16.0f / 9.0f, 0.5f, 100.0f);
+    viewMatrix = MMath::lookAt(cameraPos, cameraTarget, cameraUp);
+    modelMatrix.loadIdentity();
+
+    // Fluid sim (allocs SSBOs/compute)
+    fluidGPU = new SPHFluidGPU(30000);
+
+    // One-time instancing hookup (attribute 5 for instance pos)
+    mesh->BindInstanceBuffer(fluidGPU->GetFluidVBO(), static_cast<GLsizei>(sizeof(float) * 4));
+
+    // Wireframe box shader + VBO
+    lineShader = new Shader("shaders/lineVert.glsl", "shaders/lineFrag.glsl");
+    if (!lineShader->OnCreate()) { std::cerr << "line shader failed\n"; return false; }
+    glGenVertexArrays(1, &boxVAO);
+    glBindVertexArray(boxVAO);
+    glGenBuffers(1, &boxVBO);
+    glBindBuffer(GL_ARRAY_BUFFER, boxVBO);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(float) * 3 * 24, nullptr, GL_DYNAMIC_DRAW);
     glEnableVertexAttribArray(0);
     glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(float) * 3, (void*)0);
     glBindVertexArray(0);
-}
-void Scene0p::BoxWire::draw(Shader& lineShader, const Matrix4& P, const Matrix4& V,
-    const Matrix4& M, const Vec3& color) {
-    glUseProgram(lineShader.GetProgram());
-    glUniformMatrix4fv(lineShader.GetUniformID("projectionMatrix"), 1, GL_FALSE, P);
-    glUniformMatrix4fv(lineShader.GetUniformID("viewMatrix"), 1, GL_FALSE, V);
-    glUniformMatrix4fv(lineShader.GetUniformID("modelMatrix"), 1, GL_FALSE, M);
-    GLint lc = glGetUniformLocation(lineShader.GetProgram(), "lineColor");
-    if (lc >= 0) glUniform3f(lc, color.x, color.y, color.z);
-    glBindVertexArray(vao);
-    glDrawArrays(GL_LINES, 0, 24);
-    glBindVertexArray(0);
-    glUseProgram(0);
-}
-void Scene0p::BoxWire::destroy() {
-    if (vbo) { glDeleteBuffers(1, &vbo); vbo = 0; }
-    if (vao) { glDeleteVertexArrays(1, &vao); vao = 0; }
-}
 
-bool Scene0p::OnCreate() {
-    Debug::Info("Scene0p OnCreate", __FILE__, __LINE__);
-
-    // Camera
-    projectionMatrix = MMath::perspective(45.0f, 16.0f / 9.0f, 0.2f, 200.0f);
-    viewMatrix = MMath::lookAt(Vec3(0, 0, 18), Vec3(0, 0, 0), Vec3(0, 1, 0));
-    modelMatrix.loadIdentity();
-
-    // Fluid
-    fluidGPU = new SPHFluidGPU(30000); // choose your N
-    // (Grid build & SPH uniforms in DispatchCompute() match your existing codepath) :contentReference[oaicite:3]{index=3}
-
-    // Shaders
+    // Point-impostor shader & dummy VAO (gl_VertexID path)
     impostorShader = new Shader("shaders/particleImpostor.vert", "shaders/particleImpostor.frag");
-    if (!impostorShader->OnCreate()) { Debug::FatalError("Impostor shader create failed", __FILE__, __LINE__); }
-
-    lineShader = new Shader("shaders/lineVert.glsl", "shaders/lineFrag.glsl");
-    if (!lineShader->OnCreate()) { Debug::FatalError("Line shader create failed", __FILE__, __LINE__); }
-
-    // GPU state
-    glEnable(GL_DEPTH_TEST);
-    glEnable(GL_CULL_FACE);
-    glEnable(GL_PROGRAM_POINT_SIZE);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA); // nice for impostors (enable/disable as you like)
-
-    // Geometry for impostors and wireframe
+    if (!impostorShader->OnCreate()) { std::cerr << "impostor shader failed\n"; return false; }
     SetupImpostorVAO();
-    boxWire.init();
-    UpdateBoxWireframe();   // build once
+
+    // Initialize wire once
+    UpdateBoxWireframe();
     lastBoxCenter = fluidGPU->param_boxCenter;
     lastBoxHalf = fluidGPU->param_boxHalf;
     lastBoxEuler = fluidGPU->param_boxEulerDeg;
@@ -84,113 +95,363 @@ bool Scene0p::OnCreate() {
 }
 
 void Scene0p::OnDestroy() {
-    boxWire.destroy();
-    if (impostorVAO) { glDeleteVertexArrays(1, &impostorVAO); impostorVAO = 0; }
-    if (lineShader) { lineShader->OnDestroy(); delete lineShader; lineShader = nullptr; }
+    if (sphere) { sphere->OnDestroy(); delete sphere; sphere = nullptr; }
+    if (mesh) { mesh->OnDestroy(); delete mesh; mesh = nullptr; }
+    if (shader) { shader->OnDestroy(); delete shader; shader = nullptr; }
     if (impostorShader) { impostorShader->OnDestroy(); delete impostorShader; impostorShader = nullptr; }
     if (fluidGPU) { delete fluidGPU; fluidGPU = nullptr; }
+    if (boxVBO)   glDeleteBuffers(1, &boxVBO);
+    if (boxVAO)   glDeleteVertexArrays(1, &boxVAO);
+    if (lineShader) { lineShader->OnDestroy(); delete lineShader; lineShader = nullptr; }
+    if (impostorVAO) glDeleteVertexArrays(1, &impostorVAO);
 }
 
 void Scene0p::HandleEvents(const SDL_Event& e) {
-    if (e.type == SDL_KEYDOWN) {
+    switch (e.type) {
+    case SDL_KEYDOWN:
         switch (e.key.keysym.scancode) {
-        case SDL_SCANCODE_SPACE: // quick splash on space as a demo
-            fluidGPU->ApplyWaveImpulseGPU(2.0f, 3.5f, SDL_GetTicks() * 0.002f, Vec3(0, 1, 0), -1.0f, 2.0f);
-            break;
+        case SDL_SCANCODE_W: cameraPos.y += 0.2f; break;
+        case SDL_SCANCODE_S: cameraPos.y -= 0.2f; break;
+        case SDL_SCANCODE_A: cameraPos.x -= 0.2f; break;
+        case SDL_SCANCODE_D: cameraPos.x += 0.2f; break;
+        case SDL_SCANCODE_R: cameraPos.z += 0.2f; break;
+        case SDL_SCANCODE_E: cameraPos.z -= 0.2f; break;
+        case SDL_SCANCODE_Z: drawInWireMode = !drawInWireMode; break;
+        default: break;
         }
+        break;
+    default: break;
     }
-}
-
-void Scene0p::Update(float deltaTime) {
-    // Single member dtAccumulator; no duplicate toggle
-    // Tiny adaptive substep cap: if frame slow, reduce to 8 else 16
-    maxSubstepsPerFrame = (deltaTime > (1.0f / 50.0f)) ? 8 : 16;
-
-    dtAccumulator += deltaTime;
-    int did = 0;
-    while (dtAccumulator >= fixedDt && did < maxSubstepsPerFrame) {
-        fluidGPU->DispatchCompute();      // grid -> SPH -> OBB, minimal barriers
-        dtAccumulator -= fixedDt;
-        ++did;
-    }
-    // clamp runaway
-    if (dtAccumulator > fixedDt * 4.0f) dtAccumulator = fixedDt * 4.0f;
-
-    // If box params changed (maybe via UI), rebuild wireframe once
-    const Vec3 c = fluidGPU->param_boxCenter;
-    const Vec3 h = fluidGPU->param_boxHalf;
-    const Vec3 e = fluidGPU->param_boxEulerDeg;
-    if (c.x != lastBoxCenter.x || c.y != lastBoxCenter.y || c.z != lastBoxCenter.z ||
-        h.x != lastBoxHalf.x || h.y != lastBoxHalf.y || h.z != lastBoxHalf.z ||
-        e.x != lastBoxEuler.x || e.y != lastBoxEuler.y || e.z != lastBoxEuler.z) {
-        UpdateBoxWireframe();
-        lastBoxCenter = c; lastBoxHalf = h; lastBoxEuler = e;
-    }
-}
-
-void Scene0p::Render() {
-    glClearColor(0, 0, 0, 1);
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-
-    // Particles (impostors)
-    DrawFluidImpostors();
-
-    // Box outline
-    Matrix4 Mbox = MMath::translate(fluidGPU->param_boxCenter) *
-        MMath::scale(fluidGPU->param_boxHalf);
-    boxWire.draw(*lineShader, projectionMatrix, viewMatrix, Mbox, Vec3(0.9f, 0.9f, 0.9f));
-}
-
-void Scene0p::SetupImpostorVAO() {
-    if (impostorVAO) return;
-    glGenVertexArrays(1, &impostorVAO);
-    glBindVertexArray(impostorVAO);
-
-    // per-instance position from fluid VBO (vec4)
-    glBindBuffer(GL_ARRAY_BUFFER, fluidGPU->GetFluidVBO());
-    glEnableVertexAttribArray(5);
-    glVertexAttribPointer(5, 4, GL_FLOAT, GL_FALSE, sizeof(float) * 4, (void*)0);
-    glVertexAttribDivisor(5, 1);
-
-    glBindVertexArray(0);
-}
-
-int Scene0p::CurrentViewportHeight() const {
-    GLint vp[4]; glGetIntegerv(GL_VIEWPORT, vp);
-    return vp[3] > 0 ? vp[3] : 1080;
-}
-
-void Scene0p::DrawFluidImpostors() {
-    // refresh instance positions (maps SSBO -> VBO for fluids only)
-    if (renderFromSSBO) {
-        fluidGPU->UpdateFluidVBOFromGPU();  // keeps draw path simple/fast  :contentReference[oaicite:4]{index=4}
-    }
-
-    glUseProgram(impostorShader->GetProgram());
-    glUniformMatrix4fv(impostorShader->GetUniformID("projectionMatrix"), 1, GL_FALSE, projectionMatrix);
-    glUniformMatrix4fv(impostorShader->GetUniformID("viewMatrix"), 1, GL_FALSE, viewMatrix);
-    glUniformMatrix4fv(impostorShader->GetUniformID("modelMatrix"), 1, GL_FALSE, modelMatrix);
-
-    // Heat-map: speed in [0..150] by default
-    glUniform1i(glGetUniformLocation(impostorShader->GetProgram(), "colorMode"), 1);
-    glUniform2f(glGetUniformLocation(impostorShader->GetProgram(), "vizRange"), 0.0f, 150.0f);
-
-    // Point size based on world radius + viewport height
-    glUniform1f(glGetUniformLocation(impostorShader->GetProgram(), "particleRadius"), 0.08f);
-    glUniform1f(glGetUniformLocation(impostorShader->GetProgram(), "viewportHeight"), (float)CurrentViewportHeight());
-
-    // Bind particle SSBO for the vertex shader (heat-map fetch)
-    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, fluidGPU->ssbo); // graphics path needs its own bind  :contentReference[oaicite:5]{index=5}
-
-    glBindVertexArray(impostorVAO);
-    glDrawArraysInstanced(GL_POINTS, 0, 1, (GLsizei)fluidGPU->GetNumFluids());
-    glBindVertexArray(0);
-
-    glUseProgram(0);
 }
 
 void Scene0p::UpdateBoxWireframe() {
-    // nothing to rebuild here except you may update a cached buffer;
-    // BoxWire uses unit cube and we scale/translate via model matrix in draw().
-    // Left as hook if you later prebake a rotated OBB frame.
+    if (!fluidGPU || !boxVBO) return;
+
+    const Vec3 C = fluidGPU->param_boxCenter;
+    const Vec3 H = fluidGPU->param_boxHalf;
+    float Rm[9]; MakeRotationMat3XYZ(
+        fluidGPU->param_boxEulerDeg.x,
+        fluidGPU->param_boxEulerDeg.y,
+        fluidGPU->param_boxEulerDeg.z, Rm);
+
+    auto xform = [&](float x, float y, float z) -> Vec3 {
+        return Vec3(
+            Rm[0] * x + Rm[3] * y + Rm[6] * z + C.x,
+            Rm[1] * x + Rm[4] * y + Rm[7] * z + C.y,
+            Rm[2] * x + Rm[5] * y + Rm[8] * z + C.z);
+        };
+
+    Vec3 c[8]; int i = 0;
+    for (int sx = -1; sx <= 1; sx += 2)
+        for (int sy = -1; sy <= 1; sy += 2)
+            for (int sz = -1; sz <= 1; sz += 2)
+                c[i++] = xform(sx * H.x, sy * H.y, sz * H.z);
+
+    int E[24] = { 0,1, 0,2, 0,4, 3,1, 3,2, 3,7, 5,1, 5,4, 5,7, 6,2, 6,4, 6,7 };
+    float lines[24 * 3];
+    for (int e = 0; e < 24; ++e) {
+        Vec3 p = c[E[e]];
+        lines[e * 3 + 0] = p.x; lines[e * 3 + 1] = p.y; lines[e * 3 + 2] = p.z;
+    }
+    glBindBuffer(GL_ARRAY_BUFFER, boxVBO);
+    glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(lines), lines);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+}
+
+void Scene0p::Update(const float deltaTime) {
+    // simple anim so you can see something moving
+    ballAnimTime += deltaTime;
+    float ballX = std::sin(ballAnimTime) * 3.0f;
+    if (sphere) sphere->SetPosition(Vec3(ballX, 0.0f, 0.0f));
+    viewMatrix = MMath::lookAt(cameraPos, cameraTarget, cameraUp);
+
+    if (!fluidGPU) return;
+
+    // --- ImGui (kept intact + small adds) ---
+    ImGui::Begin("Fluid Controls");
+    ImGui::Text("FPS: %.1f", ImGui::GetIO().Framerate);
+    ImGui::Text("Particles: %zu (fluids: %zu)", fluidGPU->particles.size(), fluidGPU->GetNumFluids());
+    ImGui::Separator();
+
+    if (ImGui::Button("Preset: Stable Water")) {
+        fluidGPU->param_pause = false;
+        fluidGPU->param_h = 0.28f;
+        fluidGPU->param_restDensity = 1000.0f;
+        fluidGPU->param_gasConstant = 2000.0f;
+        fluidGPU->param_viscosity = 3.5f;
+        fluidGPU->param_gravityY = -980.0f;
+        fluidGPU->param_surfaceTension = 0.0f;
+        fluidGPU->param_timeStep = 1.0e-3f;
+        pendingReset = true;
+    }
+    if (ImGui::Button("Preset: Splashy Water")) {
+        fluidGPU->param_pause = false;
+        fluidGPU->param_h = 0.22f;
+        fluidGPU->param_restDensity = 1000.0f;
+        fluidGPU->param_gasConstant = 6000.0f;
+        fluidGPU->param_viscosity = 1.2f;
+        fluidGPU->param_gravityY = -980.0f;
+        fluidGPU->param_surfaceTension = 0.12f;
+        fluidGPU->param_timeStep = 5.0e-4f;
+        fluidGPU->param_useJitter = true;
+        fluidGPU->param_jitterAmp = 0.06f;
+        fluidGPU->param_wallRestitution = 0.05f;
+        fluidGPU->param_wallFriction = 0.05f;
+        pendingReset = true;
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Fit Camera")) {
+        Vec3 minV(FLT_MAX, FLT_MAX, FLT_MAX);
+        Vec3 maxV(-FLT_MAX, -FLT_MAX, -FLT_MAX);
+        size_t count = 0;
+        for (const auto& p : fluidGPU->particles) {
+            if (p.isGhost) continue;
+            minV.x = std::min(minV.x, p.pos.x);
+            minV.y = std::min(minV.y, p.pos.y);
+            minV.z = std::min(minV.z, p.pos.z);
+            maxV.x = std::max(maxV.x, p.pos.x);
+            maxV.y = std::max(maxV.y, p.pos.y);
+            maxV.z = std::max(maxV.z, p.pos.z);
+            ++count;
+        }
+        if (count) {
+            Vec3 center((minV.x + maxV.x) * 0.5f, (minV.y + maxV.y) * 0.5f, (minV.z + maxV.z) * 0.5f);
+            float height = (maxV.y - minV.y);
+            float width = (maxV.x - minV.x);
+            const float fovY = 45.0f * (3.14159265359f / 180.0f);
+            float halfH = std::max(height, width) * 0.5f;
+            float dist = halfH / std::tan(fovY * 0.5f) * 1.35f;
+            cameraTarget = center;
+            cameraPos = Vec3(center.x, center.y, center.z + dist);
+        }
+    }
+
+    // Sim params
+    ImGui::Checkbox("Pause simulation", &fluidGPU->param_pause);
+    ImGui::SliderFloat("h (smoothing)", &fluidGPU->param_h, 0.10f, 1.00f);
+    ImGui::SliderFloat("mass", &fluidGPU->param_mass, 1.0f, 50.0f);
+    ImGui::SliderFloat("restDensity", &fluidGPU->param_restDensity, 100.0f, 2000.0f);
+    ImGui::SliderFloat("gasConstant", &fluidGPU->param_gasConstant, 100.0f, 30000.0f);
+    ImGui::SliderFloat("viscosity", &fluidGPU->param_viscosity, 0.0f, 20.0f);
+    ImGui::SliderFloat("gravityY", &fluidGPU->param_gravityY, -5000.0f, 0.0f);
+    ImGui::SliderFloat("surfaceTension", &fluidGPU->param_surfaceTension, 0.0f, 1.0f);
+    ImGui::SliderFloat("timeStep", &fluidGPU->param_timeStep, 1e-5f, 5e-3f, "%.6f", ImGuiSliderFlags_Logarithmic);
+
+    // Performance toggles (deduped)
+    ImGui::Separator(); ImGui::Text("Performance");
+    ImGui::Checkbox("Render from SSBO (fast)", &renderFromSSBO);
+    ImGui::Checkbox("Enable ghost boundaries (slower)", &fluidGPU->param_enableGhosts);
+    ImGui::SameLine();
+    ImGui::Checkbox("Grid sort (unused)", &fluidGPU->param_enableSort);
+    ImGui::Checkbox("Use point impostors", &useImpostors);
+
+    // Box transform
+    ImGui::Separator(); ImGui::Text("Box Transform (OBB)");
+    ImGui::DragFloat3("Center", &fluidGPU->param_boxCenter.x, 0.05f);
+    ImGui::DragFloat3("Half Extents", &fluidGPU->param_boxHalf.x, 0.05f, 0.05f, 100.0f);
+    ImGui::DragFloat3("Euler XYZ", &fluidGPU->param_boxEulerDeg.x, 0.5f, -180.0f, 180.0f);
+    ImGui::SliderFloat("Wall Restitution", &fluidGPU->param_wallRestitution, 0.0f, 1.0f);
+    ImGui::SliderFloat("Wall Friction", &fluidGPU->param_wallFriction, 0.0f, 1.0f);
+    if (ImGui::Button("Rebuild Grid for Box")) {
+        fluidGPU->RecreateGridForBox();
+        UpdateBoxWireframe();
+    }
+
+    // Spawn
+    ImGui::Separator(); ImGui::Text("Spawn Layout");
+    ImGui::Checkbox("Use jitter", &fluidGPU->param_useJitter); ImGui::SameLine();
+    ImGui::SliderFloat("Jitter amp * spacing", &fluidGPU->param_jitterAmp, 0.0f, 0.5f, "%.2f"); ImGui::SameLine();
+    if (ImGui::Button("Rebuild Layout")) { pendingReset = true; }
+
+    // Waves (now GPU-only in SPHFluidGPU)
+    ImGui::Separator(); ImGui::Text("Waves");
+    static float waveAmplitude = 1.5f;
+    static float waveWavelength = 3.0f;
+    static float wavePhaseSpeed = 4.0f;
+    static int   waveDirIdx = 1; // 0:X 1:Y 2:Z
+    static float yBandMin = -std::numeric_limits<float>::infinity();
+    static float yBandMax = std::numeric_limits<float>::infinity();
+    static bool  continuousWave = false;
+    static float wavePhase = 0.0f;
+
+    ImGui::SliderFloat("Amplitude", &waveAmplitude, 0.0f, 25.0f);
+    ImGui::SliderFloat("Wavelength", &waveWavelength, 0.5f, 10.0f);
+    ImGui::SliderFloat("Phase speed", &wavePhaseSpeed, 0.0f, 20.0f);
+    ImGui::RadioButton("Dir X", &waveDirIdx, 0); ImGui::SameLine();
+    ImGui::RadioButton("Dir Y", &waveDirIdx, 1); ImGui::SameLine();
+    ImGui::RadioButton("Dir Z", &waveDirIdx, 2);
+    ImGui::InputFloat("Band Y min", &yBandMin);
+    ImGui::InputFloat("Band Y max", &yBandMax);
+    ImGui::Checkbox("Continuous wave", &continuousWave);
+    if (ImGui::Button("Impulse Now")) {
+        Vec3 dir = (waveDirIdx == 0) ? Vec3(1, 0, 0) : (waveDirIdx == 1) ? Vec3(0, 1, 0) : Vec3(0, 0, 1);
+        fluidGPU->ApplyWaveImpulse(waveAmplitude, waveWavelength, wavePhase, dir, yBandMin, yBandMax);
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Reset Simulation")) pendingReset = true;
+
+    // Visualization
+    ImGui::Separator(); ImGui::Text("Visualization");
+    static int   vizMode = 1;
+    static float rangeMin = 0.0f, rangeMax = 10.0f;
+    ImGui::Combo("Color by", &vizMode, "Depth\0Speed\0Pressure\0Density\0\0");
+    ImGui::DragFloat("Range Min", &rangeMin, 0.1f);
+    ImGui::DragFloat("Range Max", &rangeMax, 0.1f);
+    ImGui::TextDisabled("Tip: SSBO mode avoids CPU readbacks and boosts FPS.");
+    ImGui::End();
+    // --- end ImGui ---
+
+    // Update wireframe only when box params changed
+    if (lastBoxCenter.x != fluidGPU->param_boxCenter.x ||
+        lastBoxCenter.y != fluidGPU->param_boxCenter.y ||
+        lastBoxCenter.z != fluidGPU->param_boxCenter.z ||
+        lastBoxHalf.x != fluidGPU->param_boxHalf.x ||
+        lastBoxHalf.y != fluidGPU->param_boxHalf.y ||
+        lastBoxHalf.z != fluidGPU->param_boxHalf.z ||
+        lastBoxEuler.x != fluidGPU->param_boxEulerDeg.x ||
+        lastBoxEuler.y != fluidGPU->param_boxEulerDeg.y ||
+        lastBoxEuler.z != fluidGPU->param_boxEulerDeg.z) {
+        UpdateBoxWireframe();
+        lastBoxCenter = fluidGPU->param_boxCenter;
+        lastBoxHalf = fluidGPU->param_boxHalf;
+        lastBoxEuler = fluidGPU->param_boxEulerDeg;
+    }
+
+    if (pendingReset) {
+        fluidGPU->ResetSimulation();
+        fluidGPU->param_pause = false;
+        mesh->BindInstanceBuffer(fluidGPU->GetFluidVBO(), static_cast<GLsizei>(sizeof(float) * 4));
+        pendingReset = false;
+        dtAccumulator = 0.0f;
+    }
+
+    if (continuousWave) {
+        wavePhase += wavePhaseSpeed * deltaTime;
+        Vec3 dir = (waveDirIdx == 0) ? Vec3(1, 0, 0) : (waveDirIdx == 1) ? Vec3(0, 1, 0) : Vec3(0, 0, 1);
+        fluidGPU->ApplyWaveImpulse(waveAmplitude, waveWavelength, wavePhase, dir, yBandMin, yBandMax);
+    }
+
+    // Fixed-step sim loop (member accumulator + lower cap)
+    const float fixedDt = std::max(1e-6f, fluidGPU->param_timeStep);
+    dtAccumulator += deltaTime;
+
+    // simple adaptive safety: if frame is very slow, shrink the cap from 16 -> 8
+    const int cap = (deltaTime > 0.033f) ? std::min(8, maxSubstepsPerFrame) : maxSubstepsPerFrame;
+
+    int didSteps = 0;
+    while (dtAccumulator >= fixedDt && didSteps < cap) {
+        fluidGPU->DispatchCompute(fixedDt);
+        dtAccumulator -= fixedDt;
+        ++didSteps;
+    }
+    if (didSteps == cap && dtAccumulator > fixedDt) {
+        dtAccumulator = fmodf(dtAccumulator, fixedDt);
+    }
+}
+
+void Scene0p::Render() const {
+    glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+    if (drawInWireMode) glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+    else                glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+
+    // 1) Box wireframe
+    if (lineShader && boxVAO) {
+        glUseProgram(lineShader->GetProgram());
+        glUniformMatrix4fv(lineShader->GetUniformID("projectionMatrix"), 1, GL_FALSE, projectionMatrix);
+        glUniformMatrix4fv(lineShader->GetUniformID("viewMatrix"), 1, GL_FALSE, viewMatrix);
+        if (GLint col = lineShader->GetUniformID("uColor"); col != -1) glUniform3f(col, 0.85f, 0.95f, 1.0f);
+        glBindVertexArray(boxVAO);
+        glLineWidth(1.5f);
+        glDrawArrays(GL_LINES, 0, 24);
+        glBindVertexArray(0);
+        glUseProgram(0);
+    }
+
+    if (!fluidGPU) return;
+
+    // 2) Particles
+    if (useImpostors && impostorShader) {
+        DrawFluidImpostors();
+        return;
+    }
+
+    // Instanced spheres path
+    if (!renderFromSSBO) {
+        // If the VS reads instance pos from a VBO, refresh it from GPU (slow path)
+        fluidGPU->UpdateFluidVBOFromGPU();
+    }
+
+    glUseProgram(shader->GetProgram());
+    glUniformMatrix4fv(shader->GetUniformID("projectionMatrix"), 1, GL_FALSE, projectionMatrix);
+    glUniformMatrix4fv(shader->GetUniformID("viewMatrix"), 1, GL_FALSE, viewMatrix);
+
+    // Height band (for your heat map)
+    if (GLint hLoc = shader->GetUniformID("heightMinMax"); hLoc != -1) {
+        glUniform2f(hLoc,
+            fluidGPU->param_boxCenter.y - fluidGPU->param_boxHalf.y,
+            fluidGPU->param_boxCenter.y + fluidGPU->param_boxHalf.y);
+    }
+
+    if (GLint useLoc = shader->GetUniformID("useSSBO"); useLoc != -1)
+        glUniform1i(useLoc, renderFromSSBO ? 1 : 0);
+    if (GLint cmLoc = shader->GetUniformID("colorMode"); cmLoc != -1)
+        glUniform1i(cmLoc, 1); // Speed
+    if (GLint vrLoc = shader->GetUniformID("vizRange"); vrLoc != -1)
+        glUniform2f(vrLoc, 0.0f, 10.0f);
+
+    float particleRadius = std::max(0.02f, 0.5f * fluidGPU->param_h);
+    Matrix4 scaleMat = MMath::scale(particleRadius, particleRadius, particleRadius);
+    glUniformMatrix4fv(shader->GetUniformID("modelMatrix"), 1, GL_FALSE, scaleMat);
+
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, fluidGPU->ssbo);
+    mesh->RenderInstanced(GL_TRIANGLES, fluidGPU->GetNumFluids());
+    glUseProgram(0);
+}
+
+void Scene0p::SetupImpostorVAO() {
+    glGenVertexArrays(1, &impostorVAO);
+}
+
+int Scene0p::CurrentViewportHeight() const {
+    GLint vp[4] = { 0,0,0,0 };
+    glGetIntegerv(GL_VIEWPORT, vp);
+    return vp[3] > 0 ? vp[3] : 1080; // fallback
+}
+
+void Scene0p::DrawFluidImpostors() const {
+    glUseProgram(impostorShader->GetProgram());
+    glUniformMatrix4fv(impostorShader->GetUniformID("projectionMatrix"), 1, GL_FALSE, projectionMatrix);
+    glUniformMatrix4fv(impostorShader->GetUniformID("viewMatrix"), 1, GL_FALSE, viewMatrix);
+
+    // screen-space point size scale (many impostor VS expect this)
+    if (GLint s = impostorShader->GetUniformID("uPointScale"); s != -1) {
+        const float fovY = 45.0f * (3.14159265359f / 180.0f);
+        float pointScale = float(CurrentViewportHeight()) / (2.0f * tanf(fovY * 0.5f));
+        glUniform1f(s, pointScale);
+    }
+
+    if (GLint hLoc = impostorShader->GetUniformID("heightMinMax"); hLoc != -1) {
+        glUniform2f(hLoc,
+            fluidGPU->param_boxCenter.y - fluidGPU->param_boxHalf.y,
+            fluidGPU->param_boxCenter.y + fluidGPU->param_boxHalf.y);
+    }
+
+    if (GLint cmLoc = impostorShader->GetUniformID("colorMode"); cmLoc != -1)
+        glUniform1i(cmLoc, 1); // speed
+    if (GLint vrLoc = impostorShader->GetUniformID("vizRange"); vrLoc != -1)
+        glUniform2f(vrLoc, 0.0f, 10.0f);
+
+    // Particle radius (if shader needs it)
+    if (GLint r = impostorShader->GetUniformID("particleRadius"); r != -1)
+        glUniform1f(r, std::max(0.02f, 0.5f * fluidGPU->param_h));
+
+    // SSBO with all particles (VS uses gl_VertexID to index)
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, fluidGPU->ssbo);
+
+    glBindVertexArray(impostorVAO);
+    glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(fluidGPU->GetNumFluids()));
+    glBindVertexArray(0);
+    glUseProgram(0);
 }

--- a/ComponentFramework/Scene0p.cpp
+++ b/ComponentFramework/Scene0p.cpp
@@ -45,7 +45,7 @@ bool Scene0p::OnCreate() {
     viewMatrix = MMath::lookAt(cameraPos, cameraTarget, cameraUp);
     modelMatrix.loadIdentity();
 
-    fluidGPU = new SPHFluidGPU(20000); // ? You can increase this!
+    fluidGPU = new SPHFluidGPU(30000); // ? You can increase this!
 
     return true;
 }

--- a/ComponentFramework/Scene0p.h
+++ b/ComponentFramework/Scene0p.h
@@ -47,6 +47,12 @@ private:
 	bool pendingReset = false;
     
     float dtAccumulator = 0.0f;
+
+	Shader* lineShader = nullptr;
+	GLuint boxVAO = 0, boxVBO = 0;
+	void UpdateBoxWireframe(); // recompute line vertices from fluidGPU->param_box*
+	bool renderFromSSBO = true;
+
 public:
 	explicit Scene0p();
 	virtual ~Scene0p();

--- a/ComponentFramework/Scene0p.h
+++ b/ComponentFramework/Scene0p.h
@@ -12,14 +12,12 @@
 #include <glad.h>
 using namespace MATH;
 
-/// Forward declarations 
 union SDL_Event;
 
 class Scene0p : public Scene {
 private:
-    // Your existing members
     Body* sphere = nullptr;
-    Shader* shader = nullptr;         // instanced sphere shader (defaultVert/defaultFrag)
+    Shader* shader = nullptr;
     Mesh* mesh = nullptr;
     Matrix4 projectionMatrix;
     Matrix4 viewMatrix;
@@ -31,32 +29,30 @@ private:
     Vec3    cameraTarget = Vec3(0.0f, 0.0f, 0.0f);
     Vec3    cameraUp = Vec3(0.0f, 1.0f, 0.0f);
 
-    // Wireframe box
     Shader* lineShader = nullptr;
     GLuint  boxVAO = 0, boxVBO = 0;
 
-    // Performance / sim controls
     bool    pendingReset = false;
     float   ballAnimTime = 0.0f;
 
-    // Fixed-step accumulator (member, not local static)
     float   dtAccumulator = 0.0f;
-    int     maxSubstepsPerFrame = 16;        // lowered cap
+    int     maxSubstepsPerFrame = 16;
 
-    // Render fast path (single toggle)
     bool    renderFromSSBO = true;
 
-    // Track last box values to update wireframe only when something changed
     Vec3    lastBoxCenter{};
     Vec3    lastBoxHalf{};
     Vec3    lastBoxEuler{};
 
-    // Point-impostor path
     bool    useImpostors = false;
-    Shader* impostorShader = nullptr;        // shaders/particleImpostor.vert/frag
-    GLuint  impostorVAO = 0;                 // empty VAO for gl_VertexID impostors
+    Shader* impostorShader = nullptr;
+    GLuint  impostorVAO = 0;
 
-    // Helpers
+    // Visualization state
+    int     vizMode = 0;          // 0=Height,1=Speed,2=Pressure,3=Density,4=InstanceColor
+    float   vizRangeMin = 0.0f;
+    float   vizRangeMax = 10.0f;
+
     void    UpdateBoxWireframe();
     void    SetupImpostorVAO();
     void    DrawFluidImpostors() const;

--- a/ComponentFramework/Scene0p.h
+++ b/ComponentFramework/Scene0p.h
@@ -44,8 +44,9 @@ private:
 	float h = 0.28f;
 	float guiTimeStep = 0.00009f;
 
-
-
+	bool pendingReset = false;
+    
+    float dtAccumulator = 0.0f;
 public:
 	explicit Scene0p();
 	virtual ~Scene0p();

--- a/ComponentFramework/SceneManager.cpp
+++ b/ComponentFramework/SceneManager.cpp
@@ -4,133 +4,155 @@
 #include "Window.h"
 #include "Scene0p.h"
 
+#include "imgui.h"
+#include "imgui_impl_sdl2.h"
+#define IMGUI_IMPL_OPENGL_LOADER_GLAD
+#include "imgui_impl_opengl3.h"
 
-SceneManager::SceneManager(): 
-	currentScene{nullptr}, window{nullptr}, timer{nullptr},
-	fps(60), isRunning{false}, fullScreen{false} {
-	Debug::Info("Starting the SceneManager", __FILE__, __LINE__);
+SceneManager::SceneManager() :
+    currentScene{ nullptr }, window{ nullptr }, timer{ nullptr },
+    fps(60), isRunning{ false }, fullScreen{ false } {
+    Debug::Info("Starting the SceneManager", __FILE__, __LINE__);
 }
 
 SceneManager::~SceneManager() {
-	Debug::Info("Deleting the SceneManager", __FILE__, __LINE__);
+    Debug::Info("Deleting the SceneManager", __FILE__, __LINE__);
 
-	if (currentScene) {
-		currentScene->OnDestroy();
-		delete currentScene;
-		currentScene = nullptr;
-	}
-	
-	if (timer) {
-		delete timer;
-		timer = nullptr;
-	}
+    // ImGui shutdown (SDL2 + OpenGL3)
+    ImGui_ImplOpenGL3_Shutdown();
+    ImGui_ImplSDL2_Shutdown();
+    ImGui::DestroyContext();
 
-	if (window) {
-		delete window;
-		window = nullptr;
-	}
-	
+    if (currentScene) {
+        currentScene->OnDestroy();
+        delete currentScene;
+        currentScene = nullptr;
+    }
+    if (timer) {
+        delete timer;
+        timer = nullptr;
+    }
+    if (window) {
+        delete window;
+        window = nullptr;
+    }
 }
 
 bool SceneManager::Initialize(std::string name_, int width_, int height_) {
+    window = new Window();
+    if (!window->OnCreate(name_, width_, height_)) {
+        Debug::FatalError("Failed to initialize Window object", __FILE__, __LINE__);
+        return false;
+    }
 
-	window = new Window();
-	if (!window->OnCreate(name_, width_, height_)) {
-		Debug::FatalError("Failed to initialize Window object", __FILE__, __LINE__);
-		return false;
-	}
+    timer = new Timer();
+    if (timer == nullptr) {
+        Debug::FatalError("Failed to initialize Timer object", __FILE__, __LINE__);
+        return false;
+    }
 
-	timer = new Timer();
-	if (timer == nullptr) {
-		Debug::FatalError("Failed to initialize Timer object", __FILE__, __LINE__);
-		return false;
-	}
+    // ImGui init (SDL2 + OpenGL3)
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+    ImGui::StyleColorsDark();
+    ImGui_ImplSDL2_InitForOpenGL(window->getWindow(), SDL_GL_GetCurrentContext());
+    ImGui_ImplOpenGL3_Init("#version 130"); // works on GL 3.x+ (and GL 4.x core)
 
-	/********************************   Default first scene   ***********************/
-	BuildNewScene(SCENE_NUMBER::SCENE0p);
-	/********************************************************************************/
-	return true;
+    // Default first scene
+    BuildNewScene(SCENE_NUMBER::SCENE0p);
+    return true;
 }
 
-/// This is the whole game
 void SceneManager::Run() {
-	timer->Start();
-	isRunning = true;
-	while (isRunning) {
-		HandleEvents();
-		timer->UpdateFrameTicks();
-		currentScene->Update(timer->GetDeltaTime());
-		currentScene->Render();
-		
-		SDL_GL_SwapWindow(window->getWindow());
-		SDL_Delay(timer->GetSleepTime(fps));
-	}
+    timer->Start();
+    isRunning = true;
+    while (isRunning) {
+        HandleEvents();
+
+        // Begin ImGui frame BEFORE Scene Update
+        ImGui_ImplOpenGL3_NewFrame();
+        ImGui_ImplSDL2_NewFrame();
+        ImGui::NewFrame();
+
+        // Optional: quick sanity UI
+        static bool show_demo_window = true;
+        if (show_demo_window) ImGui::ShowDemoWindow(&show_demo_window);
+        ImGui::Begin("Stats");
+        ImGui::Text("Delta: %.3f ms (%.1f FPS)", timer->GetDeltaTime() * 1000.0f, 1.0f / timer->GetDeltaTime());
+        ImGui::Checkbox("Show Demo", &show_demo_window);
+        ImGui::End();
+
+        timer->UpdateFrameTicks();
+        if (currentScene) {
+            currentScene->Update(timer->GetDeltaTime()); // Scene0p builds its own ImGui here
+            currentScene->Render();
+        }
+
+        // Render ImGui AFTER scene render
+        ImGui::Render();
+
+        // Ensure UI is drawn solid (scene may have left GL in wireframe)
+        glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+
+        ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+
+        SDL_GL_SwapWindow(window->getWindow());
+        SDL_Delay(timer->GetSleepTime(fps));
+    }
 }
 
 void SceneManager::HandleEvents() {
-	SDL_Event sdlEvent;
-	while (SDL_PollEvent(&sdlEvent)) { /// Loop over all events in the SDL queue
-		if (sdlEvent.type == SDL_EventType::SDL_QUIT) {
-			isRunning = false;
-			return;
-		}
-		else if (sdlEvent.type == SDL_KEYDOWN) {
-			switch (sdlEvent.key.keysym.scancode) {
-			[[fallthrough]]; /// C17 Prevents switch/case fallthrough warnings
-			case SDL_SCANCODE_ESCAPE:
-			case SDL_SCANCODE_Q:
-				isRunning = false;
-				return;
-				
+    SDL_Event e;
+    while (SDL_PollEvent(&e)) {
+        ImGui_ImplSDL2_ProcessEvent(&e); // feed SDL2 events to ImGui
 
-			case SDL_SCANCODE_F1:
-			case SDL_SCANCODE_F2:
-			case SDL_SCANCODE_F3:
-			case SDL_SCANCODE_F4:
-			case SDL_SCANCODE_F5:
-		
-				BuildNewScene(SCENE_NUMBER::SCENE0g);
-				break;
+        if (e.type == SDL_QUIT) {
+            isRunning = false;
+            return;
+        }
 
-			default:
-				break;
-			}
-		}
-		if (currentScene == nullptr) { /// Just to be careful
-			Debug::FatalError("No currentScene", __FILE__, __LINE__);
-			isRunning = false;
-			return;
-		}
-		currentScene->HandleEvents(sdlEvent);
-	}
+        if (e.type == SDL_KEYDOWN) {
+            switch (e.key.keysym.scancode) {
+            case SDL_SCANCODE_ESCAPE:
+            case SDL_SCANCODE_Q:
+                isRunning = false; return;
+            case SDL_SCANCODE_F1:
+            case SDL_SCANCODE_F2:
+            case SDL_SCANCODE_F3:
+            case SDL_SCANCODE_F4:
+            case SDL_SCANCODE_F5:
+                BuildNewScene(SCENE_NUMBER::SCENE0p);
+                break;
+            default: break;
+            }
+        }
+
+        if (currentScene == nullptr) {
+            Debug::FatalError("No currentScene", __FILE__, __LINE__);
+            isRunning = false;
+            return;
+        }
+        currentScene->HandleEvents(e);
+    }
 }
 
 bool SceneManager::BuildNewScene(SCENE_NUMBER scene) {
-	bool status; 
+    bool status = false;
 
-	if (currentScene != nullptr) {
-		currentScene->OnDestroy();
-		delete currentScene;
-		currentScene = nullptr;
-	}
+    if (currentScene != nullptr) {
+        currentScene->OnDestroy();
+        delete currentScene;
+        currentScene = nullptr;
+    }
 
-	switch (scene) {
-	case SCENE_NUMBER::SCENE0p:
-		currentScene = new Scene0p();
-		status = currentScene->OnCreate();
-		break;
-
-	/*case SCENE_NUMBER::SCENE1g:
-		currentScene = new Scene1g();
-		status = currentScene->OnCreate();
-		break;*/
-
-	default:
-		Debug::Error("Incorrect scene number assigned in the manager", __FILE__, __LINE__);
-		currentScene = nullptr;
-		return false;
-	}
-	return true;
+    switch (scene) {
+    case SCENE_NUMBER::SCENE0p:
+        currentScene = new Scene0p();
+        status = currentScene->OnCreate();
+        break;
+    default:
+        Debug::Error("Incorrect scene number assigned in the manager", __FILE__, __LINE__);
+        return false;
+    }
+    return status;
 }
-
-

--- a/ComponentFramework/SceneManager.h
+++ b/ComponentFramework/SceneManager.h
@@ -1,7 +1,11 @@
 #ifndef SCENEMANAGER_H
 #define SCENEMANAGER_H
+#include "Scene.h"
+#include "Timer.h"
+#include "Window.h"
 
 #include <string>
+
 class SceneManager  {
 public:
 	
@@ -26,7 +30,7 @@ private:
 
 	Scene* currentScene;
 	Timer* timer;
-	Window* window;
+	Window* window; 
 
 	unsigned int fps;
 	bool isRunning;

--- a/ComponentFramework/SceneManager.h
+++ b/ComponentFramework/SceneManager.h
@@ -24,9 +24,9 @@ private:
 		SCENE6
 	};
 
-	class Scene* currentScene;
-	class Timer* timer;
-	class Window* window;
+	Scene* currentScene;
+	Timer* timer;
+	Window* window;
 
 	unsigned int fps;
 	bool isRunning;

--- a/ComponentFramework/imgui.ini
+++ b/ComponentFramework/imgui.ini
@@ -3,7 +3,7 @@ Pos=64,250
 Size=400,400
 
 [Window][Fluid Controls]
-Pos=128,1003
+Pos=1568,380
 Size=913,701
 
 [Window][Stats]

--- a/ComponentFramework/imgui.ini
+++ b/ComponentFramework/imgui.ini
@@ -3,12 +3,13 @@ Pos=64,250
 Size=400,400
 
 [Window][Fluid Controls]
-Pos=1611,383
-Size=913,701
+Pos=1529,97
+Size=913,729
 
 [Window][Stats]
-Pos=24,132
-Size=343,68
+Pos=-17,1
+Size=343,165
+Collapsed=1
 
 [Window][Dear ImGui Demo]
 Pos=1989,1081

--- a/ComponentFramework/imgui.ini
+++ b/ComponentFramework/imgui.ini
@@ -3,8 +3,8 @@ Pos=64,250
 Size=400,400
 
 [Window][Fluid Controls]
-Pos=645,1004
-Size=1498,555
+Pos=128,1003
+Size=913,701
 
 [Window][Stats]
 Pos=24,132

--- a/ComponentFramework/imgui.ini
+++ b/ComponentFramework/imgui.ini
@@ -1,10 +1,10 @@
 [Window][Debug##Default]
-Pos=60,60
+Pos=64,250
 Size=400,400
 
 [Window][Fluid Controls]
-Pos=14,231
-Size=711,1166
+Pos=645,1004
+Size=1498,555
 
 [Window][Stats]
 Pos=24,132

--- a/ComponentFramework/imgui.ini
+++ b/ComponentFramework/imgui.ini
@@ -3,7 +3,7 @@ Pos=64,250
 Size=400,400
 
 [Window][Fluid Controls]
-Pos=1568,380
+Pos=1611,383
 Size=913,701
 
 [Window][Stats]

--- a/ComponentFramework/imgui.ini
+++ b/ComponentFramework/imgui.ini
@@ -1,0 +1,16 @@
+[Window][Debug##Default]
+Pos=60,60
+Size=400,400
+
+[Window][Fluid Controls]
+Pos=14,231
+Size=711,1166
+
+[Window][Stats]
+Pos=24,132
+Size=343,68
+
+[Window][Dear ImGui Demo]
+Pos=1989,1081
+Size=550,680
+

--- a/ComponentFramework/shaders/BuildGrid.comp
+++ b/ComponentFramework/shaders/BuildGrid.comp
@@ -1,38 +1,38 @@
 #version 450
 layout(local_size_x = 256) in;
+
 struct Particle {
-    vec4 pos;
-    vec4 vel;
-    vec4 acc;
-    float density;
-    float pressure;
-    float padA;
-    float padB;
-    int isGhost;
-    int isActive;
-    int padC;
-    int pad0;
+    vec4 pos; vec4 vel; vec4 acc;
+    float density; float pressure; float padA; float padB;
+    int isGhost; int isActive; int padC; int pad0;
 };
-layout(std430, binding = 0) buffer ParticleBuf { Particle particles[]; };
-layout(std430, binding = 1) buffer CellHeadBuf { int cellHead[]; };
-layout(std430, binding = 2) buffer ParticleNextBuf { int particleNext[]; };
-layout(std430, binding = 3) buffer ParticleCellBuf { int particleCell[]; };
+
+layout(std430, binding=0) buffer Particles { Particle particles[]; };
+layout(std430, binding=1) buffer CellHead  { int cellHead[]; };
+layout(std430, binding=2) buffer NextIdx   { int particleNext[]; };
+layout(std430, binding=3) buffer PartCell  { int particleCell[]; };
+layout(std430, binding=4) buffer CellKey   { int cellKey[]; };
+
 uniform ivec3 gridSize;
 uniform float cellSize;
-uniform float box;
-uniform int numParticles; // total particle count
+uniform vec3  gridMin;
+uniform int   numParticles;
+
+int flatten(ivec3 c) { return (c.z * gridSize.y + c.y) * gridSize.x + c.x; }
+
 void main() {
-    uint id = gl_GlobalInvocationID.x;
-    if (id >= uint(numParticles)) return; // guard against extra threads
-    if (particles[id].isGhost == 1 && particles[id].isActive == 0) {
-        particleCell[id] = -1;
-        particleNext[id] = -1;
-        return;
-    }
-    vec3 pos = particles[id].pos.xyz;
-    ivec3 cellCoord = ivec3(floor((pos + vec3(box)) / cellSize));
-    cellCoord = clamp(cellCoord, ivec3(0), gridSize - 1);
-    int cellIdx = cellCoord.x + gridSize.x * (cellCoord.y + gridSize.y * cellCoord.z);
-    particleCell[id] = cellIdx;
-    particleNext[id] = atomicExchange(cellHead[cellIdx], int(id));
+    uint i = gl_GlobalInvocationID.x;
+    if (i >= uint(numParticles)) return;
+
+    particleNext[i] = -1;
+    vec3 p = particles[i].pos.xyz;
+
+    ivec3 c = ivec3(floor((p - gridMin) / cellSize));
+    c = clamp(c, ivec3(0), gridSize - ivec3(1));
+    int cell = flatten(c);
+
+    particleCell[i] = cell;
+    cellKey[i] = cell;
+    int prev = atomicExchange(cellHead[cell], int(i));
+    particleNext[i] = prev;
 }

--- a/ComponentFramework/shaders/BuildGrid.comp
+++ b/ComponentFramework/shaders/BuildGrid.comp
@@ -1,7 +1,17 @@
 #version 450
 layout(local_size_x = 256) in;
 struct Particle {
-    vec4 pos; vec4 vel; vec4 acc; float density; float pressure; int isGhost; float pad0;
+    vec4 pos;
+    vec4 vel;
+    vec4 acc;
+    float density;
+    float pressure;
+    float padA;
+    float padB;
+    int isGhost;
+    int isActive;
+    int padC;
+    int pad0;
 };
 layout(std430, binding = 0) buffer ParticleBuf { Particle particles[]; };
 layout(std430, binding = 1) buffer CellHeadBuf { int cellHead[]; };
@@ -10,8 +20,15 @@ layout(std430, binding = 3) buffer ParticleCellBuf { int particleCell[]; };
 uniform ivec3 gridSize;
 uniform float cellSize;
 uniform float box;
+uniform int numParticles; // total particle count
 void main() {
     uint id = gl_GlobalInvocationID.x;
+    if (id >= uint(numParticles)) return; // guard against extra threads
+    if (particles[id].isGhost == 1 && particles[id].isActive == 0) {
+        particleCell[id] = -1;
+        particleNext[id] = -1;
+        return;
+    }
     vec3 pos = particles[id].pos.xyz;
     ivec3 cellCoord = ivec3(floor((pos + vec3(box)) / cellSize));
     cellCoord = clamp(cellCoord, ivec3(0), gridSize - 1);

--- a/ComponentFramework/shaders/ClearGrid.comp
+++ b/ComponentFramework/shaders/ClearGrid.comp
@@ -1,8 +1,10 @@
 #version 450
 layout(local_size_x = 256) in;
-layout(std430, binding = 1) buffer CellHeadBuf { int cellHead[]; };
+
+layout(std430, binding=1) buffer CellHead { int cellHead[]; };
 uniform int numCells;
+
 void main() {
     uint i = gl_GlobalInvocationID.x;
-    if (i < numCells) cellHead[i] = -1;
+    if (i < uint(numCells)) cellHead[i] = -1;
 }

--- a/ComponentFramework/shaders/OBBConstraints.comp
+++ b/ComponentFramework/shaders/OBBConstraints.comp
@@ -1,0 +1,81 @@
+#version 450
+layout(local_size_x = 256) in;
+
+struct Particle {
+    vec4 pos;
+    vec4 vel;
+    vec4 acc;
+    float density;
+    float pressure;
+    float padA;
+    float padB;
+    int isGhost;
+    int isActive;
+    int padC;
+    int pad0;
+};
+
+layout(std430, binding=0) buffer Particles { Particle particles[]; };
+
+uniform vec3 uBoxCenter;
+uniform vec3 uBoxHalf;
+uniform mat3 uBoxRot;    // column-major, world_from_box
+uniform float uRestitution; // 0..1
+uniform float uFriction;    // 0..1
+
+// Convert world to box-local (R^T*(p-c))
+vec3 worldToLocal(vec3 p) {
+    vec3 d = p - uBoxCenter;
+    // uBoxRot is world_from_box, so local_from_world = transpose(uBoxRot)
+    return vec3(dot(d, uBoxRot[0]), dot(d, uBoxRot[1]), dot(d, uBoxRot[2]));
+}
+vec3 localToWorld(vec3 q) {
+    return uBoxCenter + uBoxRot * q;
+}
+
+void main() {
+    uint i = gl_GlobalInvocationID.x;
+    if (i >= particles.length()) return;
+
+    // Skip ghosts
+    if (particles[i].isGhost != 0) return;
+
+    vec3 pW = particles[i].pos.xyz;
+    vec3 vW = particles[i].vel.xyz;
+
+    // Transform to box local space
+    vec3 pL = worldToLocal(pW);
+
+    // Clamp to OBB AABB in local space
+    vec3 qL = clamp(pL, -uBoxHalf, uBoxHalf);
+
+    // If clamped, compute collision response
+    vec3 delta = pL - qL;
+    if (any(greaterThan(abs(delta), vec3(0.0)))) {
+        // Contact normal along the most violated axis (in local space)
+        vec3 nL = vec3(0.0);
+        vec3 d = abs(delta);
+        if (d.x >= d.y && d.x >= d.z) nL = vec3(sign(delta.x), 0.0, 0.0);
+        else if (d.y >= d.x && d.y >= d.z) nL = vec3(0.0, sign(delta.y), 0.0);
+        else nL = vec3(0.0, 0.0, sign(delta.z));
+
+        // Transform normal to world
+        vec3 nW = normalize(uBoxRot * nL);
+
+        // Correct position to the surface
+        pW = localToWorld(qL);
+
+        // Split velocity into normal/tangent and reflect with restitution + friction
+        float vn = dot(vW, nW);
+        vec3 vN = vn * nW;
+        vec3 vT = vW - vN;
+
+        vec3 vN_new = -uRestitution * vN;
+        vec3 vT_new = (1.0 - uFriction) * vT;
+
+        vW = vN_new + vT_new;
+    }
+
+    particles[i].pos.xyz = pW;
+    particles[i].vel.xyz = vW;
+}

--- a/ComponentFramework/shaders/SPHFluid.comp
+++ b/ComponentFramework/shaders/SPHFluid.comp
@@ -8,9 +8,12 @@ struct Particle {
     vec4 acc;
     float density;
     float pressure;
+    float padA;
+    float padB;
     int isGhost;
-    float pad0;
     int isActive;
+    int padC;
+    int pad0;
 };
 
 layout(std430, binding = 0) buffer ParticleBuf    { Particle particles[]; };
@@ -30,6 +33,7 @@ uniform float viscosity;
 uniform float timeStep;
 uniform vec3 gravity;
 uniform float surfaceTension; // Tunable from CPU
+uniform int numParticles; // total particle count
 
 // ----------- SPH Kernels -----------
 float poly6(float r2, float h) {
@@ -58,10 +62,15 @@ float viscLaplacian(float r, float h) {
 
 void main() {
     uint i = gl_GlobalInvocationID.x;
+    if (i >= uint(numParticles)) return; // guard against extra threads
     Particle pi = particles[i];
 
     // ---------- Ghost boundary handling ----------
     if (pi.isGhost == 1) {
+        if (pi.isActive == 0) {
+            particles[i] = pi;
+            return;
+        }
         pi.vel = vec4(0.0);
         pi.acc = vec4(0.0);
         pi.density = restDensity;
@@ -150,6 +159,7 @@ void main() {
     // ---------- Gravity and integration ----------
     vec3 fGravity = gravity * pi.density;
     vec3 acc = (fPressure + viscosity * fViscosity + fGravity + fSurfaceTension) / pi.density;
+    pi.acc = vec4(acc, 0.0); // store acceleration
 
     pi.vel.xyz += acc * timeStep;
     pi.vel.xyz *= 0.995; // Gentle damping (optional)

--- a/ComponentFramework/shaders/SPHFluid.comp
+++ b/ComponentFramework/shaders/SPHFluid.comp
@@ -156,14 +156,16 @@ void main() {
         fSurfaceTension = -surfaceTension * lapC * (gradC / gradC_len);
     }
 
-    // ---------- Gravity and integration ----------
-    vec3 fGravity = gravity * pi.density;
-    vec3 acc = (fPressure + viscosity * fViscosity + fGravity + fSurfaceTension) / pi.density;
-    pi.acc = vec4(acc, 0.0); // store acceleration
+ // ---------- Gravity and integration ----------
+vec3 fGravity = gravity * pi.density;
+vec3 acc = (fPressure + viscosity * fViscosity + fGravity + fSurfaceTension) / pi.density;
+pi.acc = vec4(acc, 0.0); // store acceleration
 
-    pi.vel.xyz += acc * timeStep;
-    pi.vel.xyz *= 0.995; // Gentle damping (optional)
-    pi.pos.xyz += pi.vel.xyz * timeStep;
+pi.vel.xyz += acc * timeStep;
+pi.vel.xyz *= 0.995; // Gentle damping (optional)
+pi.pos.xyz += pi.vel.xyz * timeStep;
+
+   
 
     // ---------- Boundaries ----------
     for (int c = 0; c < 3; ++c) {

--- a/ComponentFramework/shaders/WaveImpulse.comp
+++ b/ComponentFramework/shaders/WaveImpulse.comp
@@ -1,0 +1,31 @@
+#version 450
+layout(local_size_x=256) in;
+
+struct Particle {
+    vec4 pos; vec4 vel; vec4 acc;
+    float density; float pressure; float padA; float padB;
+    ivec4 flags; // x=isGhost
+};
+layout(std430, binding=0) buffer ParticleBuf { Particle particles[]; };
+
+layout(std140, binding=5) uniform WaveParams {
+    float amplitude;
+    float wavelength;
+    float phase;
+    vec3  dir;
+    float yMin;
+    float yMax;
+};
+
+void main() {
+    uint i = gl_GlobalInvocationID.x;
+    Particle p = particles[i];
+    if (p.flags.x != 0) return; // skip ghosts
+    if (p.pos.y < yMin || p.pos.y > yMax) return;
+    float k = (wavelength > 1e-6) ? (2.0*3.14159265 / wavelength) : 0.0;
+    float theta = k * (p.pos.x + p.pos.z) + phase;
+    float kick  = amplitude * sin(theta);
+    vec3 nDir = (length(dir) > 0.0) ? normalize(dir) : vec3(0,1,0);
+    p.vel.xyz += nDir * kick;
+    particles[i] = p;
+}

--- a/ComponentFramework/shaders/WaveImpulse.comp
+++ b/ComponentFramework/shaders/WaveImpulse.comp
@@ -1,31 +1,46 @@
-#version 450
-layout(local_size_x=256) in;
+﻿#version 450
+layout(local_size_x = 256) in;
 
-struct Particle {
-    vec4 pos; vec4 vel; vec4 acc;
-    float density; float pressure; float padA; float padB;
-    ivec4 flags; // x=isGhost
+// Match CPU side SPHParticle layout (80 bytes)
+struct SPHParticle {
+    vec4  pos;
+    vec4  vel;
+    vec4  acc;
+    float density;
+    float pressure;
+    float padA;
+    float padB;
+    int   isGhost;
+    int   isActive;
+    int   padC;
+    int   pad0;
 };
-layout(std430, binding=0) buffer ParticleBuf { Particle particles[]; };
 
-layout(std140, binding=5) uniform WaveParams {
-    float amplitude;
-    float wavelength;
-    float phase;
-    vec3  dir;
-    float yMin;
-    float yMax;
-};
+layout(std430, binding = 0) buffer ParticleBuf { SPHParticle particles[]; };
+
+// Uniforms expected by ApplyWaveImpulse() in SPHFluid3D.cpp
+uniform int   N;
+uniform float amplitude;
+uniform float wavelength;
+uniform float phase;
+uniform vec3  dir;
+uniform float yMin;
+uniform float yMax;
 
 void main() {
     uint i = gl_GlobalInvocationID.x;
-    Particle p = particles[i];
-    if (p.flags.x != 0) return; // skip ghosts
+    if (i >= uint(N)) return;
+
+    SPHParticle p = particles[i];
+    if (p.isGhost != 0) return;
     if (p.pos.y < yMin || p.pos.y > yMax) return;
-    float k = (wavelength > 1e-6) ? (2.0*3.14159265 / wavelength) : 0.0;
-    float theta = k * (p.pos.x + p.pos.z) + phase;
+    if (amplitude == 0.0 || wavelength <= 1e-6) return;
+
+    vec3 nDir = (length(dir) > 1e-6) ? normalize(dir) : vec3(0.0, 1.0, 0.0);
+    float k = 6.28318530718 / wavelength;          // 2π / λ
+    float theta = k * dot(p.pos.xyz, nDir) + phase;
     float kick  = amplitude * sin(theta);
-    vec3 nDir = (length(dir) > 0.0) ? normalize(dir) : vec3(0,1,0);
+
     p.vel.xyz += nDir * kick;
     particles[i] = p;
 }

--- a/ComponentFramework/shaders/defaultFrag.glsl
+++ b/ComponentFramework/shaders/defaultFrag.glsl
@@ -2,8 +2,7 @@
 in vec3 fragColor;
 flat in int fragGhost;
 out vec4 outColor;
-
 void main() {
-    if (fragGhost == 1) discard;
+    if (fragGhost == 1) discard;   // hide ghost particles
     outColor = vec4(fragColor, 1.0);
 }

--- a/ComponentFramework/shaders/defaultFrag.glsl
+++ b/ComponentFramework/shaders/defaultFrag.glsl
@@ -1,7 +1,9 @@
 #version 450
 in vec3 fragColor;
+flat in int fragGhost;
 out vec4 outColor;
 
 void main() {
-    outColor = vec4(fragColor, 0.8); // 0.8 = alpha for some transparency
+    if (fragGhost == 1) discard;
+    outColor = vec4(fragColor, 1.0);
 }

--- a/ComponentFramework/shaders/defaultVert.glsl
+++ b/ComponentFramework/shaders/defaultVert.glsl
@@ -1,29 +1,81 @@
 #version 450
-#extension GL_ARB_separate_shader_objects : enable
 
-layout(location = 0) in vec3 vertexPosition;
-layout(location = 1) in vec3 vertexNormal;
-layout(location = 2) in vec2 vertexUV;
-layout(location = 4) in vec3 instanceColor;
-layout(location = 5) in vec4 instancePos;
-layout(location = 6) in vec3 instanceVel;
+layout(location=0) in vec3 vertexPosition;
+layout(location=1) in vec3 vertexNormal;
+layout(location=2) in vec2 vertexUV;
+
+layout(location=4) in vec3 instanceColor;
+layout(location=5) in vec4 instancePos;
+layout(location=6) in vec3 instanceVel;
 
 uniform mat4 projectionMatrix;
 uniform mat4 viewMatrix;
-uniform mat4 modelMatrix; // Used for scaling
+uniform mat4 modelMatrix;
+
+// 0=Depth, 1=Speed, 2=Pressure, 3=Density, 4=InstanceColor
+uniform int colorMode = 1;
+uniform vec2 vizRange = vec2(0.0, 10.0);
+uniform int useSSBO = 1;
 
 out vec3 fragColor;
+flat out int fragGhost;
+
+struct Particle {
+    vec4 pos; vec4 vel; vec4 acc;
+    float density; float pressure; float padA; float padB;
+    ivec4 flags; // x=isGhost, y=isActive, z=padC, w=pad0
+};
+
+layout(std430, binding=0) buffer ParticleBuf { Particle particles[]; };
+
+float remap01(float v, float lo, float hi) {
+    return clamp((v - lo) / max(1e-8, hi - lo), 0.0, 1.0);
+}
+vec3 turbo(float t) {
+    t = clamp(t, 0.0, 1.0);
+    float r = clamp(abs(2.0*t - 0.5), 0.0, 1.0);
+    float g = clamp(1.0 - abs(2.0*t - 1.0), 0.0, 1.0);
+    float b = clamp(abs(2.0*t - 1.5), 0.0, 1.0);
+    return vec3(r, g, b);
+}
 
 void main() {
-    mat4 model = modelMatrix;
-    model[3].xyz += instancePos.xyz;
-    gl_Position = projectionMatrix * viewMatrix * model * vec4(vertexPosition, 1.0);
+    vec3 ipos;
+    vec3 ivel;
+    float density = 0.0;
+    float pressure = 0.0;
+    int isGhost = 0;
 
-    // --- Gradient by depth (y) ---
-    float minY = -7.0; // Set to your box min y
-    float maxY =  7.0; // Set to your box max y
-    float t = clamp((instancePos.y - minY) / (maxY - minY), 0.0, 1.0);
+    if (useSSBO == 1) {
+        Particle p = particles[gl_InstanceID];
+        ipos = p.pos.xyz;
+        ivel = p.vel.xyz;
+        density = p.density;
+        pressure = p.pressure;
+        isGhost = p.flags.x;
+    } else {
+        ipos = instancePos.xyz;
+        ivel = instanceVel.xyz;
+    }
 
-    // Blue at bottom, cyan at top
-    fragColor = mix(vec3(0.1, 0.4, 1.0), vec3(0.5, 1.0, 1.0), t);
+    mat4 M = modelMatrix;
+    M[3].xyz += ipos;
+
+    gl_Position = projectionMatrix * viewMatrix * M * vec4(vertexPosition, 1.0);
+
+    if (colorMode == 4) {
+        fragColor = instanceColor;
+    } else if (colorMode == 0) {
+        float t = remap01(ipos.y, -7.0, 7.0);
+        fragColor = mix(vec3(0.1,0.4,1.0), vec3(0.5,1.0,1.0), t);
+    } else if (colorMode == 1) {
+        float speed = length(ivel);
+        fragColor = turbo(remap01(speed, vizRange.x, vizRange.y));
+    } else if (colorMode == 2) {
+        fragColor = turbo(remap01(pressure, vizRange.x, vizRange.y));
+    } else {
+        fragColor = turbo(remap01(density, vizRange.x, vizRange.y));
+    }
+
+    fragGhost = isGhost;
 }

--- a/ComponentFramework/shaders/defaultVert.glsl
+++ b/ComponentFramework/shaders/defaultVert.glsl
@@ -4,78 +4,67 @@ layout(location=0) in vec3 vertexPosition;
 layout(location=1) in vec3 vertexNormal;
 layout(location=2) in vec2 vertexUV;
 
-layout(location=4) in vec3 instanceColor;
+// Instance data (optional when useSSBO==1)
 layout(location=5) in vec4 instancePos;
-layout(location=6) in vec3 instanceVel;
+layout(location=4) in vec3 instanceColor;
 
-uniform mat4 projectionMatrix;
-uniform mat4 viewMatrix;
-uniform mat4 modelMatrix;
+uniform mat4 projectionMatrix, viewMatrix, modelMatrix;
 
-// 0=Depth, 1=Speed, 2=Pressure, 3=Density, 4=InstanceColor
-uniform int colorMode = 1;
-uniform vec2 vizRange = vec2(0.0, 10.0);
-uniform int useSSBO = 1;
+// 0 = Height, 1 = Speed, 2 = Pressure, 3 = Density, 4 = InstanceColor
+uniform int  colorMode = 1;
+uniform vec2 vizRange  = vec2(0.0, 1.0);
+
+// Controls
+uniform vec2 heightMinMax = vec2(-7.0, 7.0);
+uniform int  useSSBO = 1; // 1 = use SSBO positions, 0 = use instancePos
+
+// SSBO with particle data
+struct Particle {
+    vec4 pos; vec4 vel; vec4 acc;
+    float density; float pressure; float padA; float padB;
+    ivec4 flags; // x=isGhost
+};
+layout(std430, binding=0) buffer ParticleBuf { Particle particles[]; };
 
 out vec3 fragColor;
 flat out int fragGhost;
 
-struct Particle {
-    vec4 pos; vec4 vel; vec4 acc;
-    float density; float pressure; float padA; float padB;
-    ivec4 flags; // x=isGhost, y=isActive, z=padC, w=pad0
-};
-
-layout(std430, binding=0) buffer ParticleBuf { Particle particles[]; };
-
 float remap01(float v, float lo, float hi) {
-    return clamp((v - lo) / max(1e-8, hi - lo), 0.0, 1.0);
+    return clamp((v - lo) / max(1e-6, hi - lo), 0.0, 1.0);
 }
+
 vec3 turbo(float t) {
     t = clamp(t, 0.0, 1.0);
-    float r = clamp(abs(2.0*t - 0.5), 0.0, 1.0);
-    float g = clamp(1.0 - abs(2.0*t - 1.0), 0.0, 1.0);
-    float b = clamp(abs(2.0*t - 1.5), 0.0, 1.0);
-    return vec3(r, g, b);
+    return vec3(0.1357 + 4.0*t - 4.5*t*t,
+                0.0000 + 2.0*t - 1.0*t*t,
+                0.6667 - 1.5*t + 1.0*t*t);
 }
 
 void main() {
-    vec3 ipos;
-    vec3 ivel;
-    float density = 0.0;
-    float pressure = 0.0;
-    int isGhost = 0;
+    int idx = gl_InstanceID;
+    Particle p = particles[idx];
+    fragGhost  = p.flags.x;
 
-    if (useSSBO == 1) {
-        Particle p = particles[gl_InstanceID];
-        ipos = p.pos.xyz;
-        ivel = p.vel.xyz;
-        density = p.density;
-        pressure = p.pressure;
-        isGhost = p.flags.x;
-    } else {
-        ipos = instancePos.xyz;
-        ivel = instanceVel.xyz;
-    }
+    // Select world-space instance position
+    vec3 basePos = (useSSBO == 1) ? p.pos.xyz : instancePos.xyz;
 
-    mat4 M = modelMatrix;
-    M[3].xyz += ipos;
+    // Transform: translate mesh instance by basePos
+    vec4 world = modelMatrix * vec4(vertexPosition, 1.0);
+    world.xyz += basePos;
+    gl_Position = projectionMatrix * viewMatrix * world;
 
-    gl_Position = projectionMatrix * viewMatrix * M * vec4(vertexPosition, 1.0);
-
+    // Color selection
     if (colorMode == 4) {
         fragColor = instanceColor;
     } else if (colorMode == 0) {
-        float t = remap01(ipos.y, -7.0, 7.0);
+        float t = remap01(basePos.y, heightMinMax.x, heightMinMax.y);
         fragColor = mix(vec3(0.1,0.4,1.0), vec3(0.5,1.0,1.0), t);
     } else if (colorMode == 1) {
-        float speed = length(ivel);
+        float speed = length(p.vel.xyz);
         fragColor = turbo(remap01(speed, vizRange.x, vizRange.y));
     } else if (colorMode == 2) {
-        fragColor = turbo(remap01(pressure, vizRange.x, vizRange.y));
+        fragColor = turbo(remap01(p.pressure, vizRange.x, vizRange.y));
     } else {
-        fragColor = turbo(remap01(density, vizRange.x, vizRange.y));
+        fragColor = turbo(remap01(p.density,  vizRange.x, vizRange.y));
     }
-
-    fragGhost = isGhost;
 }

--- a/ComponentFramework/shaders/defaultVert.glsl
+++ b/ComponentFramework/shaders/defaultVert.glsl
@@ -3,26 +3,21 @@
 layout(location=0) in vec3 vertexPosition;
 layout(location=1) in vec3 vertexNormal;
 layout(location=2) in vec2 vertexUV;
-
-// Instance data (optional when useSSBO==1)
 layout(location=5) in vec4 instancePos;
 layout(location=4) in vec3 instanceColor;
 
 uniform mat4 projectionMatrix, viewMatrix, modelMatrix;
 
 // 0 = Height, 1 = Speed, 2 = Pressure, 3 = Density, 4 = InstanceColor
-uniform int  colorMode = 1;
+uniform int  colorMode = 0;
 uniform vec2 vizRange  = vec2(0.0, 1.0);
-
-// Controls
 uniform vec2 heightMinMax = vec2(-7.0, 7.0);
-uniform int  useSSBO = 1; // 1 = use SSBO positions, 0 = use instancePos
+uniform int  useSSBO = 1;
 
-// SSBO with particle data
 struct Particle {
     vec4 pos; vec4 vel; vec4 acc;
     float density; float pressure; float padA; float padB;
-    ivec4 flags; // x=isGhost
+    ivec4 flags;
 };
 layout(std430, binding=0) buffer ParticleBuf { Particle particles[]; };
 
@@ -31,6 +26,26 @@ flat out int fragGhost;
 
 float remap01(float v, float lo, float hi) {
     return clamp((v - lo) / max(1e-6, hi - lo), 0.0, 1.0);
+}
+
+// Blue->Red (with a slight mid transition for readability)
+vec3 heightPalette(float t) {
+    // t in [0,1]
+    // bottom deep blue, then through cyan/purple, up to red
+    vec3 c1 = vec3(0.05, 0.15, 0.85);   // low
+    vec3 c2 = vec3(0.25, 0.60, 0.90);   // mid-low
+    vec3 c3 = vec3(0.80, 0.30, 0.40);   // mid-high
+    vec3 c4 = vec3(0.95, 0.10, 0.10);   // high
+    if (t < 0.33) {
+        float u = t / 0.33;
+        return mix(c1, c2, u);
+    } else if (t < 0.66) {
+        float u = (t - 0.33) / 0.33;
+        return mix(c2, c3, u);
+    } else {
+        float u = (t - 0.66) / 0.34;
+        return mix(c3, c4, u);
+    }
 }
 
 vec3 turbo(float t) {
@@ -45,20 +60,17 @@ void main() {
     Particle p = particles[idx];
     fragGhost  = p.flags.x;
 
-    // Select world-space instance position
     vec3 basePos = (useSSBO == 1) ? p.pos.xyz : instancePos.xyz;
 
-    // Transform: translate mesh instance by basePos
     vec4 world = modelMatrix * vec4(vertexPosition, 1.0);
     world.xyz += basePos;
     gl_Position = projectionMatrix * viewMatrix * world;
 
-    // Color selection
     if (colorMode == 4) {
         fragColor = instanceColor;
-    } else if (colorMode == 0) {
+    } else if (colorMode == 0) { // Height
         float t = remap01(basePos.y, heightMinMax.x, heightMinMax.y);
-        fragColor = mix(vec3(0.1,0.4,1.0), vec3(0.5,1.0,1.0), t);
+        fragColor = heightPalette(t);
     } else if (colorMode == 1) {
         float speed = length(p.vel.xyz);
         fragColor = turbo(remap01(speed, vizRange.x, vizRange.y));

--- a/ComponentFramework/shaders/lineFrag.glsl
+++ b/ComponentFramework/shaders/lineFrag.glsl
@@ -1,0 +1,4 @@
+#version 450
+uniform vec3 uColor = vec3(0.8, 0.9, 1.0);
+out vec4 outColor;
+void main() { outColor = vec4(uColor, 1.0); }

--- a/ComponentFramework/shaders/lineVert.glsl
+++ b/ComponentFramework/shaders/lineVert.glsl
@@ -1,0 +1,7 @@
+#version 450
+layout(location=0) in vec3 inPos;
+uniform mat4 projectionMatrix;
+uniform mat4 viewMatrix;
+void main() {
+    gl_Position = projectionMatrix * viewMatrix * vec4(inPos, 1.0);
+}

--- a/ComponentFramework/shaders/particleImpostor.frag
+++ b/ComponentFramework/shaders/particleImpostor.frag
@@ -1,0 +1,13 @@
+#version 450
+in flat int vIsGhost;
+out vec4 outColor;
+
+void main() {
+    if (vIsGhost == 1) discard;
+    vec2 uv = gl_PointCoord * 2.0 - 1.0;
+    float r2 = dot(uv, uv);
+    if (r2 > 1.0) discard; // round sprite
+    // Simple shading
+    vec3 col = mix(vec3(0.15,0.4,1.0), vec3(0.9,0.5,1.0), clamp(1.0 - r2, 0.0, 1.0));
+    outColor = vec4(col, 1.0);
+}

--- a/ComponentFramework/shaders/particleImpostor.frag
+++ b/ComponentFramework/shaders/particleImpostor.frag
@@ -1,13 +1,62 @@
 #version 450
 in flat int vIsGhost;
+in float vHeight;
+in float vSpeed;
+in float vPressure;
+in float vDensity;
+
+uniform int  colorMode;
+uniform vec2 vizRange;
+uniform vec2 heightMinMax;
+
 out vec4 outColor;
+
+float remap01(float v, float lo, float hi){
+    return clamp((v - lo) / max(1e-6, hi - lo), 0.0, 1.0);
+}
+
+vec3 heightPalette(float t) {
+    vec3 c1 = vec3(0.05, 0.15, 0.85);
+    vec3 c2 = vec3(0.25, 0.60, 0.90);
+    vec3 c3 = vec3(0.80, 0.30, 0.40);
+    vec3 c4 = vec3(0.95, 0.10, 0.10);
+    if (t < 0.33) {
+        float u = t / 0.33;
+        return mix(c1, c2, u);
+    } else if (t < 0.66) {
+        float u = (t - 0.33) / 0.33;
+        return mix(c2, c3, u);
+    } else {
+        float u = (t - 0.66) / 0.34;
+        return mix(c3, c4, u);
+    }
+}
+
+vec3 turbo(float t) {
+    t = clamp(t, 0.0, 1.0);
+    return vec3(0.1357 + 4.0*t - 4.5*t*t,
+                0.0000 + 2.0*t - 1.0*t*t,
+                0.6667 - 1.5*t + 1.0*t*t);
+}
 
 void main() {
     if (vIsGhost == 1) discard;
     vec2 uv = gl_PointCoord * 2.0 - 1.0;
-    float r2 = dot(uv, uv);
-    if (r2 > 1.0) discard; // round sprite
-    // Simple shading
-    vec3 col = mix(vec3(0.15,0.4,1.0), vec3(0.9,0.5,1.0), clamp(1.0 - r2, 0.0, 1.0));
+    if (dot(uv, uv) > 1.0) discard;
+
+    vec3 col;
+    if (colorMode == 0) {
+        float t = remap01(vHeight, heightMinMax.x, heightMinMax.y);
+        col = heightPalette(t);
+    } else if (colorMode == 1) {
+        col = turbo(remap01(vSpeed, vizRange.x, vizRange.y));
+    } else if (colorMode == 2) {
+        col = turbo(remap01(vPressure, vizRange.x, vizRange.y));
+    } else if (colorMode == 3) {
+        col = turbo(remap01(vDensity, vizRange.x, vizRange.y));
+    } else {
+        col = vec3(1.0); // instanceColor not used in impostor path; fallback white
+    }
+
     outColor = vec4(col, 1.0);
 }

--- a/ComponentFramework/shaders/particleImpostor.vert
+++ b/ComponentFramework/shaders/particleImpostor.vert
@@ -1,0 +1,35 @@
+#version 450
+layout(location=0) in vec2 dummy; // not used
+
+uniform mat4 projectionMatrix, viewMatrix;
+uniform float particleRadius; // world-space
+uniform int   colorMode;      // reuse your modes if you want
+
+struct Particle {
+    vec4 pos; vec4 vel; vec4 acc;
+    float density; float pressure; float padA; float padB;
+    ivec4 flags;
+};
+layout(std430, binding=0) buffer ParticleBuf { Particle particles[]; };
+
+out flat int vIsGhost;
+out vec3 vAttrib; // pack what you want for color (e.g., vel, pressure)
+
+void main() {
+    int idx = gl_VertexID; // when drawing with glDrawArraysInstanced base+instance, or use gl_InstanceID
+    Particle p = particles[idx];
+    vIsGhost = p.flags.x;
+    vAttrib = p.vel.xyz; // example
+
+    vec4 viewPos = viewMatrix * vec4(p.pos.xyz, 1.0);
+    gl_Position = projectionMatrix * viewPos;
+
+    // Project radius to pixels
+    float dist = max(1e-4, -viewPos.z);
+    // Assuming perspective with symmetric frustum; extract focal length from projectionMatrix
+    float fy = 1.0 / projectionMatrix[1][1]; // tan(fovY/2) ~= 1/f[1][1]
+    float halfScreenHeight = 1.0; // NDC scale; we’ll set gl_PointSize in pixels via viewport scale in app
+    float worldToNDC = particleRadius / (fy * dist);
+    // App should pass in viewport height (pixels) if desired. Simpler: compute on CPU; or set gl_PointSize in app.
+    gl_PointSize = 0.0; // set in app via uniform if you prefer; or compute with viewport height.
+}

--- a/ComponentFramework/shaders/particleImpostor.vert
+++ b/ComponentFramework/shaders/particleImpostor.vert
@@ -1,9 +1,11 @@
 #version 450
-layout(location=0) in vec2 dummy; // not used
+layout(location=0) in vec2 dummy;
 
 uniform mat4 projectionMatrix, viewMatrix;
-uniform float particleRadius; // world-space
-uniform int   colorMode;      // reuse your modes if you want
+uniform float particleRadius;
+uniform int   colorMode;        // same semantics
+uniform vec2  vizRange;
+uniform vec2  heightMinMax;
 
 struct Particle {
     vec4 pos; vec4 vel; vec4 acc;
@@ -13,23 +15,21 @@ struct Particle {
 layout(std430, binding=0) buffer ParticleBuf { Particle particles[]; };
 
 out flat int vIsGhost;
-out vec3 vAttrib; // pack what you want for color (e.g., vel, pressure)
+out float vHeight;
+out float vSpeed;
+out float vPressure;
+out float vDensity;
 
 void main() {
-    int idx = gl_VertexID; // when drawing with glDrawArraysInstanced base+instance, or use gl_InstanceID
+    int idx = gl_VertexID;
     Particle p = particles[idx];
     vIsGhost = p.flags.x;
-    vAttrib = p.vel.xyz; // example
+    vHeight  = p.pos.y;
+    vSpeed   = length(p.vel.xyz);
+    vPressure = p.pressure;
+    vDensity  = p.density;
 
     vec4 viewPos = viewMatrix * vec4(p.pos.xyz, 1.0);
     gl_Position = projectionMatrix * viewPos;
-
-    // Project radius to pixels
-    float dist = max(1e-4, -viewPos.z);
-    // Assuming perspective with symmetric frustum; extract focal length from projectionMatrix
-    float fy = 1.0 / projectionMatrix[1][1]; // tan(fovY/2) ~= 1/f[1][1]
-    float halfScreenHeight = 1.0; // NDC scale; we’ll set gl_PointSize in pixels via viewport scale in app
-    float worldToNDC = particleRadius / (fy * dist);
-    // App should pass in viewport height (pixels) if desired. Simpler: compute on CPU; or set gl_PointSize in app.
-    gl_PointSize = 0.0; // set in app via uniform if you prefer; or compute with viewport height.
+    gl_PointSize = particleRadius; // actual size refined in frag if needed
 }

--- a/glsl ComponentFramework/shaders/particleImpostor.frag
+++ b/glsl ComponentFramework/shaders/particleImpostor.frag
@@ -1,0 +1,13 @@
+#version 450
+in flat int vIsGhost;
+out vec4 outColor;
+
+void main() {
+    if (vIsGhost == 1) discard;
+    vec2 uv = gl_PointCoord * 2.0 - 1.0;
+    float r2 = dot(uv, uv);
+    if (r2 > 1.0) discard; // round sprite
+    // Simple shading
+    vec3 col = mix(vec3(0.15,0.4,1.0), vec3(0.9,0.5,1.0), clamp(1.0 - r2, 0.0, 1.0));
+    outColor = vec4(col, 1.0);
+}

--- a/glsl ComponentFramework/shaders/particleImpostor.vert
+++ b/glsl ComponentFramework/shaders/particleImpostor.vert
@@ -1,0 +1,35 @@
+#version 450
+layout(location=0) in vec2 dummy; // not used
+
+uniform mat4 projectionMatrix, viewMatrix;
+uniform float particleRadius; // world-space
+uniform int   colorMode;      // reuse your modes if you want
+
+struct Particle {
+    vec4 pos; vec4 vel; vec4 acc;
+    float density; float pressure; float padA; float padB;
+    ivec4 flags;
+};
+layout(std430, binding=0) buffer ParticleBuf { Particle particles[]; };
+
+out flat int vIsGhost;
+out vec3 vAttrib; // pack what you want for color (e.g., vel, pressure)
+
+void main() {
+    int idx = gl_VertexID; // when drawing with glDrawArraysInstanced base+instance, or use gl_InstanceID
+    Particle p = particles[idx];
+    vIsGhost = p.flags.x;
+    vAttrib = p.vel.xyz; // example
+
+    vec4 viewPos = viewMatrix * vec4(p.pos.xyz, 1.0);
+    gl_Position = projectionMatrix * viewPos;
+
+    // Project radius to pixels
+    float dist = max(1e-4, -viewPos.z);
+    // Assuming perspective with symmetric frustum; extract focal length from projectionMatrix
+    float fy = 1.0 / projectionMatrix[1][1]; // tan(fovY/2) ~= 1/f[1][1]
+    float halfScreenHeight = 1.0; // NDC scale; we’ll set gl_PointSize in pixels via viewport scale in app
+    float worldToNDC = particleRadius / (fy * dist);
+    // App should pass in viewport height (pixels) if desired. Simpler: compute on CPU; or set gl_PointSize in app.
+    gl_PointSize = 0.0; // set in app via uniform if you prefer; or compute with viewport height.
+}


### PR DESCRIPTION
## Summary
- guard GPU kernels against out-of-range invocations
- store acceleration and expose particle count to shaders

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685185d3afdc83268c620cbb35e93e4c