### PR TITLE
Add screen-space fluid surface rendering (SSFR) pipeline

### DIFF
--- a/ComponentFramework/Scene0p.cpp
+++ b/ComponentFramework/Scene0p.cpp
@@ -78,6 +78,29 @@ bool Scene0p::OnCreate() {
     if (!impostorShader->OnCreate()) { std::cerr << "impostor shader failed\n"; return false; }
     SetupImpostorVAO();
 
+    // SSFR shaders
+    ssfrDepthShader = new Shader("shaders/fluidDepth.vert", "shaders/fluidDepth.frag");
+    if (!ssfrDepthShader->OnCreate()) { std::cerr << "ssfrDepth shader failed\n"; return false; }
+
+    ssfrSmoothShader = new Shader("shaders/screenQuad.vert", "shaders/depthSmooth.frag");
+    if (!ssfrSmoothShader->OnCreate()) { std::cerr << "depthSmooth shader failed\n"; return false; }
+
+    ssfrThickShader = new Shader("shaders/fluidDepth.vert", "shaders/fluidThickness.frag");
+    if (!ssfrThickShader->OnCreate()) { std::cerr << "fluidThickness shader failed\n"; return false; }
+
+    ssfrCompositeShader = new Shader("shaders/screenQuad.vert", "shaders/fluidComposite.frag");
+    if (!ssfrCompositeShader->OnCreate()) { std::cerr << "fluidComposite shader failed\n"; return false; }
+
+    glGenVertexArrays(1, &ssfrQuadVAO);
+    glEnable(GL_PROGRAM_POINT_SIZE);
+
+    {
+        GLint vp[4] = {0,0,0,0};
+        glGetIntegerv(GL_VIEWPORT, vp);
+        if (vp[2] > 0 && vp[3] > 0)
+            InitSSFRBuffers(vp[2], vp[3]);
+    }
+
     UpdateBoxWireframe();
     lastBoxCenter = fluidGPU->param_boxCenter;
     lastBoxHalf = fluidGPU->param_boxHalf;
@@ -100,6 +123,13 @@ void Scene0p::OnDestroy() {
     if (boxVAO)   glDeleteVertexArrays(1, &boxVAO);
     if (lineShader) { lineShader->OnDestroy(); delete lineShader; lineShader = nullptr; }
     if (impostorVAO) glDeleteVertexArrays(1, &impostorVAO);
+
+    if (ssfrDepthShader)     { ssfrDepthShader->OnDestroy();     delete ssfrDepthShader;     ssfrDepthShader     = nullptr; }
+    if (ssfrSmoothShader)    { ssfrSmoothShader->OnDestroy();    delete ssfrSmoothShader;    ssfrSmoothShader    = nullptr; }
+    if (ssfrThickShader)     { ssfrThickShader->OnDestroy();     delete ssfrThickShader;     ssfrThickShader     = nullptr; }
+    if (ssfrCompositeShader) { ssfrCompositeShader->OnDestroy(); delete ssfrCompositeShader; ssfrCompositeShader = nullptr; }
+    if (ssfrQuadVAO)         glDeleteVertexArrays(1, &ssfrQuadVAO);
+    DestroySSFRBuffers();
 }
 
 void Scene0p::HandleEvents(const SDL_Event& e) {
@@ -159,6 +189,14 @@ void Scene0p::Update(const float deltaTime) {
     float ballX = std::sin(ballAnimTime) * 3.0f;
     if (sphere) sphere->SetPosition(Vec3(ballX, 0.0f, 0.0f));
     viewMatrix = MMath::lookAt(cameraPos, cameraTarget, cameraUp);
+
+    // Resize SSFR FBOs if viewport changed
+    {
+        GLint vp[4] = {0,0,0,0};
+        glGetIntegerv(GL_VIEWPORT, vp);
+        if (vp[2] > 0 && vp[3] > 0 && (vp[2] != ssfrW || vp[3] != ssfrH))
+            InitSSFRBuffers(vp[2], vp[3]);
+    }
 
     if (!fluidGPU) return;
 
@@ -284,6 +322,27 @@ void Scene0p::Update(const float deltaTime) {
     ImGui::DragFloat("Range Min", &vizRangeMin, 0.1f);
     ImGui::DragFloat("Range Max", &vizRangeMax, 0.1f);
     ImGui::TextDisabled("Height mode ignores Range Min/Max and uses box Y extents.");
+
+    ImGui::Separator();
+    if (ImGui::CollapsingHeader("Water Rendering", ImGuiTreeNodeFlags_DefaultOpen)) {
+        ImGui::Checkbox("Enable Water Surface Rendering", &useWaterRendering);
+        if (useWaterRendering) {
+            ImGui::SliderInt("Smooth Iterations",  &smoothIterations,    0,    20);
+            ImGui::SliderFloat("Filter Radius (px)", &smoothFilterRadius, 1.0f, 30.0f);
+            ImGui::SliderFloat("Depth Falloff",      &smoothDepthFalloff, 0.01f, 1.0f);
+            ImGui::Separator();
+            ImGui::ColorEdit3("Water Extinction",   waterExtinction);
+            ImGui::SliderFloat("Thickness Scale",   &thicknessScale,      0.01f, 20.0f);
+            ImGui::ColorEdit3("Deep Water Color",   deepWaterColor);
+            ImGui::Separator();
+            ImGui::SliderFloat3("Sun Dir (World)",  sunDirWorld,         -1.0f,  1.0f);
+            ImGui::ColorEdit3("Sun Color",          sunColor);
+            ImGui::SliderFloat("Specular Power",    &specularPower,       8.0f,  1024.0f);
+            ImGui::SliderFloat("Specular Strength", &specularStrength,    0.0f,  3.0f);
+            ImGui::SliderFloat("Refraction",        &refractionStrength,  0.0f,  0.2f);
+            ImGui::SliderFloat("Fresnel Bias",      &fresnelBias,         0.0f,  0.3f);
+        }
+    }
     ImGui::End();
 
     if (lastBoxCenter.x != fluidGPU->param_boxCenter.x ||
@@ -331,6 +390,13 @@ void Scene0p::Update(const float deltaTime) {
 }
 
 void Scene0p::Render() const {
+    // Water surface rendering: all 5 passes handled inside RenderSSFR()
+    if (useWaterRendering && ssfrW > 0 && ssfrDepthShader && fluidGPU) {
+        glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+        RenderSSFR();
+        return;
+    }
+
     glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
@@ -419,4 +485,265 @@ void Scene0p::DrawFluidImpostors() const {
     glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(fluidGPU->GetNumFluids()));
     glBindVertexArray(0);
     glUseProgram(0);
+}
+
+// ---------------------------------------------------------------------------
+// SSFR helpers
+// ---------------------------------------------------------------------------
+
+static GLuint MakeR32FFBO(GLuint& texOut, int w, int h) {
+    glGenTextures(1, &texOut);
+    glBindTexture(GL_TEXTURE_2D, texOut);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_R32F, w, h, 0, GL_RED, GL_FLOAT, nullptr);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+    GLuint fbo;
+    glGenFramebuffers(1, &fbo);
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texOut, 0);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    return fbo;
+}
+
+void Scene0p::InitSSFRBuffers(int w, int h) {
+    DestroySSFRBuffers();
+    ssfrW = w; ssfrH = h;
+
+    // --- Pass 1: depth FBO (R32F color + depth renderbuffer) ---
+    glGenTextures(1, &ssfrDepthTex);
+    glBindTexture(GL_TEXTURE_2D, ssfrDepthTex);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_R32F, w, h, 0, GL_RED, GL_FLOAT, nullptr);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+    glGenRenderbuffers(1, &ssfrDepthRBO);
+    glBindRenderbuffer(GL_RENDERBUFFER, ssfrDepthRBO);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, w, h);
+
+    glGenFramebuffers(1, &ssfrDepthFBO);
+    glBindFramebuffer(GL_FRAMEBUFFER, ssfrDepthFBO);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, ssfrDepthTex, 0);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, ssfrDepthRBO);
+
+    // --- Pass 2: ping-pong smooth FBOs (R32F) ---
+    for (int i = 0; i < 2; ++i)
+        ssfrSmoothFBO[i] = MakeR32FFBO(ssfrSmoothTex[i], w, h);
+
+    // --- Pass 3: thickness FBO (R32F, additive) ---
+    ssfrThickFBO = MakeR32FFBO(ssfrThickTex, w, h);
+
+    // --- Pass 4: background FBO (RGBA8 + depth) ---
+    glGenTextures(1, &ssfrBgTex);
+    glBindTexture(GL_TEXTURE_2D, ssfrBgTex);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+    glGenRenderbuffers(1, &ssfrBgRBO);
+    glBindRenderbuffer(GL_RENDERBUFFER, ssfrBgRBO);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, w, h);
+
+    glGenFramebuffers(1, &ssfrBgFBO);
+    glBindFramebuffer(GL_FRAMEBUFFER, ssfrBgFBO);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, ssfrBgTex, 0);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, ssfrBgRBO);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    glBindTexture(GL_TEXTURE_2D, 0);
+    glBindRenderbuffer(GL_RENDERBUFFER, 0);
+}
+
+void Scene0p::DestroySSFRBuffers() {
+    if (ssfrDepthFBO)    { glDeleteFramebuffers(1, &ssfrDepthFBO);    ssfrDepthFBO = 0; }
+    if (ssfrDepthTex)    { glDeleteTextures(1, &ssfrDepthTex);        ssfrDepthTex = 0; }
+    if (ssfrDepthRBO)    { glDeleteRenderbuffers(1, &ssfrDepthRBO);   ssfrDepthRBO = 0; }
+    for (int i = 0; i < 2; ++i) {
+        if (ssfrSmoothFBO[i]) { glDeleteFramebuffers(1, &ssfrSmoothFBO[i]); ssfrSmoothFBO[i] = 0; }
+        if (ssfrSmoothTex[i]) { glDeleteTextures(1, &ssfrSmoothTex[i]);     ssfrSmoothTex[i] = 0; }
+    }
+    if (ssfrThickFBO)    { glDeleteFramebuffers(1, &ssfrThickFBO);    ssfrThickFBO = 0; }
+    if (ssfrThickTex)    { glDeleteTextures(1, &ssfrThickTex);        ssfrThickTex = 0; }
+    if (ssfrBgFBO)       { glDeleteFramebuffers(1, &ssfrBgFBO);       ssfrBgFBO = 0; }
+    if (ssfrBgTex)       { glDeleteTextures(1, &ssfrBgTex);           ssfrBgTex = 0; }
+    if (ssfrBgRBO)       { glDeleteRenderbuffers(1, &ssfrBgRBO);      ssfrBgRBO = 0; }
+    ssfrW = ssfrH = 0;
+}
+
+void Scene0p::RenderSSFR() const {
+    if (!fluidGPU || ssfrW <= 0 || ssfrH <= 0) return;
+
+    const float radius = std::max(0.02f, 0.5f * fluidGPU->param_h);
+    const auto  nFluid = static_cast<GLsizei>(fluidGPU->GetNumFluids());
+
+    glEnable(GL_PROGRAM_POINT_SIZE);
+
+    // -----------------------------------------------------------------------
+    // Pass 1 — Sphere depth: render spherical impostors, write view-space Z
+    // -----------------------------------------------------------------------
+    glBindFramebuffer(GL_FRAMEBUFFER, ssfrDepthFBO);
+    glViewport(0, 0, ssfrW, ssfrH);
+    glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    glEnable(GL_DEPTH_TEST);
+    glDepthFunc(GL_LESS);
+    glDisable(GL_BLEND);
+
+    glUseProgram(ssfrDepthShader->GetProgram());
+    glUniformMatrix4fv(ssfrDepthShader->GetUniformID("projectionMatrix"), 1, GL_FALSE, projectionMatrix);
+    glUniformMatrix4fv(ssfrDepthShader->GetUniformID("viewMatrix"),       1, GL_FALSE, viewMatrix);
+    if (GLint r = ssfrDepthShader->GetUniformID("particleRadius"); r != -1)
+        glUniform1f(r, radius);
+    if (GLint r = ssfrDepthShader->GetUniformID("viewportH"); r != -1)
+        glUniform1f(r, static_cast<float>(ssfrH));
+
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, fluidGPU->ssbo);
+    glBindVertexArray(impostorVAO);
+    glDrawArrays(GL_POINTS, 0, nFluid);
+
+    // -----------------------------------------------------------------------
+    // Pass 2 — Bilateral depth smoothing (ping-pong, N iterations)
+    // -----------------------------------------------------------------------
+    glDisable(GL_DEPTH_TEST);
+    glDisable(GL_BLEND);
+
+    // Initial source is the raw depth texture
+    GLuint srcTex = ssfrDepthTex;
+    int    pingPong = 0;
+
+    glUseProgram(ssfrSmoothShader->GetProgram());
+    glUniform2f(ssfrSmoothShader->GetUniformID("screenSize"),    static_cast<float>(ssfrW), static_cast<float>(ssfrH));
+    glUniform1f(ssfrSmoothShader->GetUniformID("filterRadius"),  smoothFilterRadius);
+    glUniform1f(ssfrSmoothShader->GetUniformID("depthFalloff"),  smoothDepthFalloff);
+
+    glBindVertexArray(ssfrQuadVAO);
+
+    for (int iter = 0; iter < smoothIterations; ++iter) {
+        // Horizontal pass
+        glBindFramebuffer(GL_FRAMEBUFFER, ssfrSmoothFBO[pingPong]);
+        glClear(GL_COLOR_BUFFER_BIT);
+        glActiveTexture(GL_TEXTURE0);
+        glBindTexture(GL_TEXTURE_2D, srcTex);
+        glUniform1i(ssfrSmoothShader->GetUniformID("depthTex"), 0);
+        glUniform2f(ssfrSmoothShader->GetUniformID("filterDir"), 1.0f, 0.0f);
+        glDrawArrays(GL_TRIANGLES, 0, 3);
+
+        srcTex   = ssfrSmoothTex[pingPong];
+        pingPong = 1 - pingPong;
+
+        // Vertical pass
+        glBindFramebuffer(GL_FRAMEBUFFER, ssfrSmoothFBO[pingPong]);
+        glClear(GL_COLOR_BUFFER_BIT);
+        glActiveTexture(GL_TEXTURE0);
+        glBindTexture(GL_TEXTURE_2D, srcTex);
+        glUniform1i(ssfrSmoothShader->GetUniformID("depthTex"), 0);
+        glUniform2f(ssfrSmoothShader->GetUniformID("filterDir"), 0.0f, 1.0f);
+        glDrawArrays(GL_TRIANGLES, 0, 3);
+
+        srcTex   = ssfrSmoothTex[pingPong];
+        pingPong = 1 - pingPong;
+    }
+
+    // After all iterations, srcTex holds the final smoothed depth
+    GLuint finalSmooth = srcTex;
+
+    // -----------------------------------------------------------------------
+    // Pass 3 — Thickness accumulation (additive blending, no depth test)
+    // -----------------------------------------------------------------------
+    glBindFramebuffer(GL_FRAMEBUFFER, ssfrThickFBO);
+    glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+    glDisable(GL_DEPTH_TEST);
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_ONE, GL_ONE); // additive
+
+    glUseProgram(ssfrThickShader->GetProgram());
+    glUniformMatrix4fv(ssfrThickShader->GetUniformID("projectionMatrix"), 1, GL_FALSE, projectionMatrix);
+    glUniformMatrix4fv(ssfrThickShader->GetUniformID("viewMatrix"),       1, GL_FALSE, viewMatrix);
+    if (GLint r = ssfrThickShader->GetUniformID("particleRadius"); r != -1)
+        glUniform1f(r, radius);
+    if (GLint r = ssfrThickShader->GetUniformID("viewportH"); r != -1)
+        glUniform1f(r, static_cast<float>(ssfrH));
+
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, fluidGPU->ssbo);
+    glBindVertexArray(impostorVAO);
+    glDrawArrays(GL_POINTS, 0, nFluid);
+
+    // -----------------------------------------------------------------------
+    // Pass 4 — Background scene (box wireframe on black sky)
+    // -----------------------------------------------------------------------
+    glBindFramebuffer(GL_FRAMEBUFFER, ssfrBgFBO);
+    glClearColor(0.03f, 0.05f, 0.08f, 1.0f); // dark night sky
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    glEnable(GL_DEPTH_TEST);
+    glDisable(GL_BLEND);
+
+    if (lineShader && boxVAO) {
+        glUseProgram(lineShader->GetProgram());
+        glUniformMatrix4fv(lineShader->GetUniformID("projectionMatrix"), 1, GL_FALSE, projectionMatrix);
+        glUniformMatrix4fv(lineShader->GetUniformID("viewMatrix"),       1, GL_FALSE, viewMatrix);
+        if (GLint c = lineShader->GetUniformID("uColor"); c != -1)
+            glUniform3f(c, 0.6f, 0.75f, 1.0f);
+        glBindVertexArray(boxVAO);
+        glLineWidth(1.5f);
+        glDrawArrays(GL_LINES, 0, 24);
+        glBindVertexArray(0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Pass 5 — Composite: normals + Fresnel + specular + refraction + tint
+    // -----------------------------------------------------------------------
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    glViewport(0, 0, ssfrW, ssfrH);
+    glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    glDisable(GL_DEPTH_TEST);
+    glDisable(GL_BLEND);
+
+    glUseProgram(ssfrCompositeShader->GetProgram());
+
+    // Bind textures
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, finalSmooth);
+    glUniform1i(ssfrCompositeShader->GetUniformID("smoothDepthTex"), 0);
+
+    glActiveTexture(GL_TEXTURE1);
+    glBindTexture(GL_TEXTURE_2D, ssfrThickTex);
+    glUniform1i(ssfrCompositeShader->GetUniformID("thicknessTex"), 1);
+
+    glActiveTexture(GL_TEXTURE2);
+    glBindTexture(GL_TEXTURE_2D, ssfrBgTex);
+    glUniform1i(ssfrCompositeShader->GetUniformID("backgroundTex"), 2);
+
+    glUniformMatrix4fv(ssfrCompositeShader->GetUniformID("projectionMatrix"), 1, GL_FALSE, projectionMatrix);
+    glUniformMatrix4fv(ssfrCompositeShader->GetUniformID("viewMatrix"),       1, GL_FALSE, viewMatrix);
+    glUniform2f(ssfrCompositeShader->GetUniformID("screenSize"),
+                static_cast<float>(ssfrW), static_cast<float>(ssfrH));
+
+    // Lighting & water appearance
+    glUniform3fv(ssfrCompositeShader->GetUniformID("sunDirWorld"),     1, sunDirWorld);
+    glUniform3fv(ssfrCompositeShader->GetUniformID("sunColor"),        1, sunColor);
+    glUniform1f(ssfrCompositeShader->GetUniformID("specularPower"),    specularPower);
+    glUniform1f(ssfrCompositeShader->GetUniformID("specularStrength"), specularStrength);
+    glUniform3fv(ssfrCompositeShader->GetUniformID("extinction"),      1, waterExtinction);
+    glUniform1f(ssfrCompositeShader->GetUniformID("thicknessScale"),   thicknessScale);
+    glUniform1f(ssfrCompositeShader->GetUniformID("refractionStrength"), refractionStrength);
+    glUniform1f(ssfrCompositeShader->GetUniformID("fresnelBias"),      fresnelBias);
+    glUniform3fv(ssfrCompositeShader->GetUniformID("deepWaterColor"),  1, deepWaterColor);
+
+    glBindVertexArray(ssfrQuadVAO);
+    glDrawArrays(GL_TRIANGLES, 0, 3);
+    glBindVertexArray(0);
+    glUseProgram(0);
+
+    // Restore state
+    glEnable(GL_DEPTH_TEST);
+    glDisable(GL_BLEND);
+    glActiveTexture(GL_TEXTURE0);
 }

--- a/ComponentFramework/Scene0p.h
+++ b/ComponentFramework/Scene0p.h
@@ -58,6 +58,48 @@ private:
     void    DrawFluidImpostors() const;
     int     CurrentViewportHeight() const;
 
+    // --- Screen-Space Fluid Rendering ---
+    Shader* ssfrDepthShader     = nullptr;
+    Shader* ssfrSmoothShader    = nullptr;
+    Shader* ssfrThickShader     = nullptr;
+    Shader* ssfrCompositeShader = nullptr;
+    GLuint  ssfrQuadVAO         = 0;
+
+    GLuint  ssfrDepthFBO        = 0;
+    GLuint  ssfrDepthTex        = 0;
+    GLuint  ssfrDepthRBO        = 0;
+
+    GLuint  ssfrSmoothFBO[2]    = {0, 0};
+    GLuint  ssfrSmoothTex[2]    = {0, 0};
+
+    GLuint  ssfrThickFBO        = 0;
+    GLuint  ssfrThickTex        = 0;
+
+    GLuint  ssfrBgFBO           = 0;
+    GLuint  ssfrBgTex           = 0;
+    GLuint  ssfrBgRBO           = 0;
+
+    int     ssfrW               = 0;
+    int     ssfrH               = 0;
+
+    bool    useWaterRendering   = true;
+    int     smoothIterations    = 5;
+    float   smoothFilterRadius  = 10.0f;
+    float   smoothDepthFalloff  = 0.1f;
+    float   waterExtinction[3]  = {0.45f, 0.15f, 0.05f};
+    float   thicknessScale      = 1.0f;
+    float   sunDirWorld[3]      = {0.4f, 1.0f, 0.5f};
+    float   sunColor[3]         = {1.0f, 0.97f, 0.9f};
+    float   deepWaterColor[3]   = {0.02f, 0.08f, 0.25f};
+    float   specularPower       = 256.0f;
+    float   specularStrength    = 0.8f;
+    float   refractionStrength  = 0.04f;
+    float   fresnelBias         = 0.02f;
+
+    void    InitSSFRBuffers(int w, int h);
+    void    RenderSSFR() const;
+    void    DestroySSFRBuffers();
+
 public:
     explicit Scene0p();
     ~Scene0p() override;

--- a/ComponentFramework/shaders/depthSmooth.frag
+++ b/ComponentFramework/shaders/depthSmooth.frag
@@ -1,0 +1,32 @@
+#version 450
+uniform sampler2D depthTex;
+uniform vec2      screenSize;
+uniform vec2      filterDir;    // (1,0) horizontal pass, (0,1) vertical pass
+uniform float     filterRadius; // half-kernel size in pixels
+uniform float     depthFalloff; // bilateral depth sigma (view-space units)
+
+in vec2 vTexCoord;
+layout(location=0) out float outSmooth;
+
+void main() {
+    float center = texture(depthTex, vTexCoord).r;
+    if (center == 0.0) { outSmooth = 0.0; return; }
+
+    float sigmaS = max(1.0, filterRadius * 0.4);
+    int   halfK  = int(filterRadius);
+
+    float sum = 0.0, wsum = 0.0;
+    for (int i = -halfK; i <= halfK; ++i) {
+        vec2  off = filterDir * float(i) / screenSize;
+        float d   = texture(depthTex, vTexCoord + off).r;
+        if (d == 0.0) continue;
+
+        float ws = exp(-float(i * i) / (2.0 * sigmaS * sigmaS));
+        float dd = d - center;
+        float wd = exp(-(dd * dd) / (2.0 * depthFalloff * depthFalloff));
+        float w  = ws * wd;
+        sum  += d * w;
+        wsum += w;
+    }
+    outSmooth = (wsum > 1e-6) ? sum / wsum : center;
+}

--- a/ComponentFramework/shaders/fluidComposite.frag
+++ b/ComponentFramework/shaders/fluidComposite.frag
@@ -1,0 +1,94 @@
+#version 450
+uniform sampler2D smoothDepthTex;
+uniform sampler2D thicknessTex;
+uniform sampler2D backgroundTex;
+uniform mat4      projectionMatrix;
+uniform mat4      viewMatrix;
+uniform vec2      screenSize;
+uniform vec3      sunDirWorld;        // world-space sun direction (normalized)
+uniform vec3      sunColor;
+uniform float     specularPower;
+uniform float     specularStrength;
+uniform vec3      extinction;         // Beer-Lambert coefficients per RGB channel
+uniform float     thicknessScale;
+uniform float     refractionStrength;
+uniform float     fresnelBias;
+uniform vec3      deepWaterColor;
+
+in vec2 vTexCoord;
+layout(location=0) out vec4 outColor;
+
+// Reconstruct view-space position from stored view-space Z and screen UV
+vec3 viewPosFromZ(vec2 uv, float vz) {
+    vec2 ndc = uv * 2.0 - 1.0;
+    return vec3(
+        ndc.x / projectionMatrix[0][0] * (-vz),
+        ndc.y / projectionMatrix[1][1] * (-vz),
+        vz
+    );
+}
+
+void main() {
+    float vz = texture(smoothDepthTex, vTexCoord).r;
+
+    // No fluid at this pixel — show background as-is
+    if (vz == 0.0) {
+        outColor = texture(backgroundTex, vTexCoord);
+        return;
+    }
+
+    vec2 px = 1.0 / screenSize;
+
+    // Reconstruct surface position
+    vec3 pos = viewPosFromZ(vTexCoord, vz);
+
+    // Forward-difference normal reconstruction
+    float vzR = texture(smoothDepthTex, vTexCoord + vec2(px.x, 0.0)).r;
+    float vzU = texture(smoothDepthTex, vTexCoord + vec2(0.0, px.y)).r;
+    vec3 posR = (vzR != 0.0) ? viewPosFromZ(vTexCoord + vec2(px.x, 0.0), vzR) : pos;
+    vec3 posU = (vzU != 0.0) ? viewPosFromZ(vTexCoord + vec2(0.0, px.y), vzU) : pos;
+
+    vec3 dX = posR - pos;
+    vec3 dY = posU - pos;
+    vec3 N  = (length(dX) > 1e-5 && length(dY) > 1e-5)
+              ? normalize(cross(dX, dY))
+              : vec3(0.0, 0.0, 1.0);
+    if (N.z < 0.0) N = -N; // ensure normal faces camera
+
+    // View direction (from surface toward camera origin)
+    vec3 V = normalize(-pos);
+
+    // Fresnel (Schlick)
+    float cosN = max(0.0, dot(N, V));
+    float F    = fresnelBias + (1.0 - fresnelBias) * pow(1.0 - cosN, 5.0);
+
+    // Transform sun to view space for shading
+    vec3 sunView = normalize(mat3(viewMatrix) * normalize(sunDirWorld));
+
+    // Blinn-Phong specular
+    vec3  H    = normalize(sunView + V);
+    float spec = pow(max(0.0, dot(N, H)), specularPower);
+
+    // Refraction: sample background at normal-distorted UV
+    vec2 refractUV = clamp(vTexCoord + N.xy * refractionStrength, vec2(0.001), vec2(0.999));
+    vec3 bgSample  = texture(backgroundTex, refractUV).rgb;
+
+    // Beer-Lambert absorption from fluid thickness
+    float thick    = max(0.0, texture(thicknessTex, vTexCoord).r * thicknessScale);
+    vec3  transmit = exp(-extinction * thick);
+
+    // Transmitted color = background tinted by water absorption
+    float avgTrans = dot(transmit, vec3(1.0 / 3.0));
+    vec3 transmitted = mix(deepWaterColor, bgSample * transmit, clamp(avgTrans, 0.0, 1.0));
+
+    // Simplified environment reflection (overcast sky blue)
+    vec3 envReflect = vec3(0.05, 0.12, 0.28);
+
+    // Fresnel blend: thin/normal-incidence → refracted; thick/grazing → reflected
+    vec3 surfaceColor = mix(transmitted, envReflect, F);
+
+    // Sun specular highlight
+    surfaceColor += sunColor * spec * specularStrength;
+
+    outColor = vec4(clamp(surfaceColor, 0.0, 1.0), 1.0);
+}

--- a/ComponentFramework/shaders/fluidDepth.frag
+++ b/ComponentFramework/shaders/fluidDepth.frag
@@ -1,0 +1,28 @@
+#version 450
+uniform mat4 projectionMatrix;
+uniform float particleRadius;
+
+in vec3 vViewPos;
+in flat int vIsGhost;
+
+layout(location=0) out float outViewZ;
+
+void main() {
+    if (vIsGhost == 1) discard;
+
+    // gl_PointCoord Y increases downward; flip to get view-space Y (up = positive)
+    vec2 disc = vec2(gl_PointCoord.x, 1.0 - gl_PointCoord.y) * 2.0 - 1.0;
+    float r2 = dot(disc, disc);
+    if (r2 > 1.0) discard;
+
+    // Sphere surface hit point in view space (billboard facing camera)
+    float nz = sqrt(1.0 - r2);
+    vec3 hit = vViewPos + vec3(disc, nz) * particleRadius;
+
+    // Write correct sphere depth to depth buffer
+    vec4 clip = projectionMatrix * vec4(hit, 1.0);
+    gl_FragDepth = (clip.z / clip.w + 1.0) * 0.5;
+
+    // View-space Z (negative for geometry in front of camera)
+    outViewZ = hit.z;
+}

--- a/ComponentFramework/shaders/fluidDepth.vert
+++ b/ComponentFramework/shaders/fluidDepth.vert
@@ -1,0 +1,30 @@
+#version 450
+layout(location=0) in vec2 dummy;
+
+uniform mat4 projectionMatrix, viewMatrix;
+uniform float particleRadius;
+uniform float viewportH;
+
+struct Particle {
+    vec4 pos; vec4 vel; vec4 acc;
+    float density; float pressure; float padA; float padB;
+    ivec4 flags;
+};
+layout(std430, binding=0) buffer ParticleBuf { Particle particles[]; };
+
+out vec3 vViewPos;
+out flat int vIsGhost;
+
+void main() {
+    Particle p = particles[gl_VertexID];
+    vIsGhost = p.flags.x;
+
+    vec4 vp = viewMatrix * vec4(p.pos.xyz, 1.0);
+    vViewPos = vp.xyz;
+    gl_Position = projectionMatrix * vp;
+
+    // Screen-space diameter: 2r * (proj_y_scale / -viewZ) * (H/2)
+    float sz = 2.0 * particleRadius * projectionMatrix[1][1]
+               / max(0.001, -vp.z) * (viewportH * 0.5);
+    gl_PointSize = max(2.0, sz);
+}

--- a/ComponentFramework/shaders/fluidThickness.frag
+++ b/ComponentFramework/shaders/fluidThickness.frag
@@ -1,0 +1,16 @@
+#version 450
+in vec3 vViewPos;
+in flat int vIsGhost;
+
+layout(location=0) out float outThick;
+
+void main() {
+    if (vIsGhost == 1) discard;
+
+    vec2 disc = gl_PointCoord * 2.0 - 1.0;
+    float r2 = dot(disc, disc);
+    if (r2 > 1.0) discard;
+
+    // Gaussian soft blob contribution — accumulated additively
+    outThick = exp(-4.0 * r2) * 0.05;
+}

--- a/ComponentFramework/shaders/screenQuad.vert
+++ b/ComponentFramework/shaders/screenQuad.vert
@@ -1,0 +1,9 @@
+#version 450
+out vec2 vTexCoord;
+
+void main() {
+    // Generates a fullscreen triangle covering NDC [-1,1]^2 from 3 vertices — no buffer needed
+    vec2 pos = vec2((gl_VertexID << 1) & 2, gl_VertexID & 2);
+    gl_Position = vec4(pos * 2.0 - 1.0, 0.0, 1.0);
+    vTexCoord = pos;
+}


### PR DESCRIPTION
## Summary
Implements a complete screen-space fluid rendering (SSFR) pipeline that renders realistic water surfaces from particle-based fluid simulations. The system uses a multi-pass approach to compute depth, smooth it bilaterally, accumulate thickness, and composite the final water surface with lighting and refraction effects.

## Key Changes

- **Multi-pass rendering pipeline**: Implements 5 rendering passes:
  1. Sphere depth pass — renders particle impostors to capture fluid surface depth
  2. Bilateral depth smoothing — ping-pong filtering to smooth noisy depth (configurable iterations)
  3. Thickness accumulation — additive blending to compute fluid thickness for absorption
  4. Background scene — renders wireframe box on dark sky
  5. Composite pass — combines depth, thickness, and background with Fresnel, specular highlights, refraction, and Beer-Lambert absorption

- **Framebuffer management**: Creates and manages multiple FBOs with appropriate texture formats (R32F for depth/thickness, RGBA8 for background), with automatic reallocation on viewport resize

- **Water appearance controls**: Adds comprehensive ImGui controls for:
  - Smoothing parameters (iterations, filter radius, depth falloff)
  - Water color properties (extinction coefficients, deep water color, thickness scale)
  - Lighting (sun direction, color, specular power/strength)
  - Refraction and Fresnel bias

- **Shader implementations**:
  - `fluidDepth.vert/frag` — renders spherical particle impostors with correct depth
  - `fluidThickness.frag` — accumulates Gaussian thickness contributions
  - `depthSmooth.frag` — bilateral filtering for smooth surface reconstruction
  - `fluidComposite.frag` — final shading with normal reconstruction, Fresnel, specular, refraction, and absorption
  - `screenQuad.vert` — fullscreen triangle generation for post-processing passes

- **Resource lifecycle**: Proper initialization in `OnCreate()`, cleanup in `OnDestroy()`, and dynamic reallocation in `Update()` when viewport changes

## Implementation Details

- Uses view-space depth for all calculations, enabling efficient normal reconstruction via forward differences
- Bilateral filtering preserves sharp edges while smoothing noise
- Fresnel effect blends between refracted (thin water) and reflected (grazing angles) appearance
- Beer-Lambert law applies exponential absorption based on fluid thickness and wavelength-dependent extinction
- Additive blending for thickness accumulation allows overlapping particles to contribute correctly
- Fullscreen triangle rendering avoids vertex buffer overhead for post-processing passes

