### PR TITLE
Realistic water rendering (SSFR) + procedural river/stream simulation

### DIFF
--- a/ComponentFramework/SPHFluid3D.cpp
+++ b/ComponentFramework/SPHFluid3D.cpp
@@ -37,7 +37,9 @@ SPHFluidGPU::SPHFluidGPU(size_t numParticles_)
     sphGridShader = LoadComputeShader("shaders/SPHFluid.comp");
     radixSortShader = LoadComputeShader("shaders/RadixSort.comp");
     obbConstraintShader = LoadComputeShader("shaders/OBBConstraints.comp");
-    waveImpulseShader = LoadComputeShader("shaders/WaveImpulse.comp"); // NEW
+    waveImpulseShader = LoadComputeShader("shaders/WaveImpulse.comp");
+    terrainConstraintShader = LoadComputeShader("shaders/TerrainConstraints.comp");
+    streamEmitShader = LoadComputeShader("shaders/StreamEmit.comp");
 
     // 1) Build particle array (also sets 'box' from OBB half)
     InitializeParticles();
@@ -66,6 +68,9 @@ SPHFluidGPU::~SPHFluidGPU() {
     glDeleteProgram(radixSortShader);
     glDeleteProgram(obbConstraintShader);
     glDeleteProgram(waveImpulseShader);
+    if (terrainConstraintShader) glDeleteProgram(terrainConstraintShader);
+    if (streamEmitShader)        glDeleteProgram(streamEmitShader);
+    if (terrainSSBO)             glDeleteBuffers(1, &terrainSSBO);
 }
 
 void SPHFluidGPU::InitializeParticles() {
@@ -90,20 +95,77 @@ void SPHFluidGPU::InitializeParticles() {
         +spacing * param_jitterAmp);
     auto j = [&]() -> float { return param_useJitter ? jitterDist(rng) : 0.0f; };
 
-    // Fill a block at the bottom
-    for (int x = 0; x < fluidSide && count < (int)numParticles; ++x)
-        for (int y = 0; y < fluidLayersY && count < (int)numParticles; ++y)
-            for (int z = 0; z < fluidSide && count < (int)numParticles; ++z) {
-                SPHParticle p{};
-                p.pos = Vec4(-box * 0.7f + x * spacing + j(),
-                    -box + spacing + y * spacing + j(),
-                    -box * 0.7f + z * spacing + j(), 0.0f);
-                p.vel = Vec4(0, 0, 0, 0);
-                p.acc = Vec4(0, 0, 0, 0);
-                p.density = p.pressure = 0.0f;
-                p.isGhost = 0; p.isActive = 0; p.pad0 = 0;
-                particles.push_back(p); ++count;
+    if (riverMode && !terrainHeights.empty()) {
+        // Distribute particles along the river channel
+        float xMin  = terrainWorldMinX;
+        float zMin  = terrainWorldMinZ;
+        float xSize = terrainWorldSizeX;
+        float zSize = terrainWorldSizeZ;
+        float yBase = param_boxCenter.y - param_boxHalf.y;
+
+        // Sample terrain height at (wx, wz)
+        auto sampleH = [&](float wx, float wz) -> float {
+            float u = (wx - xMin) / xSize * float(terrainW - 1);
+            float v = (wz - zMin) / zSize * float(terrainH - 1);
+            u = std::max(0.0f, std::min(float(terrainW - 2), u));
+            v = std::max(0.0f, std::min(float(terrainH - 2), v));
+            int ix = int(u), iz = int(v);
+            float fx = u - ix, fz = v - iz;
+            int W = terrainW;
+            float h00 = terrainHeights[ ix      +  iz      * W];
+            float h10 = terrainHeights[(ix + 1) +  iz      * W];
+            float h01 = terrainHeights[ ix      + (iz + 1) * W];
+            float h11 = terrainHeights[(ix + 1) + (iz + 1) * W];
+            return h00*(1-fx)*(1-fz) + h10*fx*(1-fz) + h01*(1-fx)*fz + h11*fx*fz;
+        };
+
+        // Walk along the channel and pack particles in
+        for (float wz = zMin + spacing; wz < zMin + zSize - spacing && count < (int)numParticles; wz += spacing) {
+            float centerX = param_boxCenter.x + riverAmp * std::sinf(riverFreq * wz + riverPhase);
+            for (float wx = centerX - riverChannelWidth; wx <= centerX + riverChannelWidth && count < (int)numParticles; wx += spacing) {
+                float ty = sampleH(wx, wz);
+                for (float wy = ty + spacing; wy <= ty + 2.5f && count < (int)numParticles; wy += spacing) {
+                    SPHParticle p{};
+                    p.pos = Vec4(wx + j(), wy + j(), wz + j(), 0.0f);
+                    p.vel = Vec4(0, 0, 2.0f, 0); // initial flow velocity
+                    p.acc = Vec4(0, 0, 0, 0);
+                    p.density = p.pressure = 0.0f;
+                    p.isGhost = 0; p.isActive = 0; p.pad0 = 0;
+                    particles.push_back(p); ++count;
+                }
             }
+        }
+        // Fill remaining particle slots at emitter if channel wasn't enough
+        while (count < (int)numParticles) {
+            std::uniform_real_distribution<float> rx(-riverChannelWidth * 0.5f, riverChannelWidth * 0.5f);
+            std::uniform_real_distribution<float> ry(0.0f, 1.5f);
+            float wx = riverEmitterPos.x + rx(rng);
+            float wz = riverEmitterPos.z + rx(rng);
+            float ty = sampleH(wx, wz);
+            SPHParticle p{};
+            p.pos = Vec4(wx, ty + ry(rng), wz, 0.0f);
+            p.vel = Vec4(0, 0, 2.0f, 0);
+            p.acc = Vec4(0, 0, 0, 0);
+            p.density = p.pressure = 0.0f;
+            p.isGhost = 0; p.isActive = 0; p.pad0 = 0;
+            particles.push_back(p); ++count;
+        }
+    } else {
+        // Standard box fill
+        for (int x = 0; x < fluidSide && count < (int)numParticles; ++x)
+            for (int y = 0; y < fluidLayersY && count < (int)numParticles; ++y)
+                for (int z = 0; z < fluidSide && count < (int)numParticles; ++z) {
+                    SPHParticle p{};
+                    p.pos = Vec4(-box * 0.7f + x * spacing + j(),
+                        -box + spacing + y * spacing + j(),
+                        -box * 0.7f + z * spacing + j(), 0.0f);
+                    p.vel = Vec4(0, 0, 0, 0);
+                    p.acc = Vec4(0, 0, 0, 0);
+                    p.density = p.pressure = 0.0f;
+                    p.isGhost = 0; p.isActive = 0; p.pad0 = 0;
+                    particles.push_back(p); ++count;
+                }
+    }
 
     // Create axis-aligned ghost shell (used if param_enableGhosts is true)
     auto add_ghost = [&](float x, float y, float z) {
@@ -392,7 +454,7 @@ void SPHFluidGPU::DispatchCompute(float overrideDt) {
     glUniform1f(glGetUniformLocation(sphGridShader, "restDensity"), param_restDensity);
     glUniform1f(glGetUniformLocation(sphGridShader, "gasConstant"), param_gasConstant);
     glUniform1f(glGetUniformLocation(sphGridShader, "viscosity"), param_viscosity);
-    glUniform3f(glGetUniformLocation(sphGridShader, "gravity"), 0.0f, param_gravityY, 0.0f);
+    glUniform3f(glGetUniformLocation(sphGridShader, "gravity"), param_gravityX, param_gravityY, param_gravityZ);
     glUniform1f(glGetUniformLocation(sphGridShader, "surfaceTension"), param_surfaceTension);
     glUniform1f(glGetUniformLocation(sphGridShader, "box"), box);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, ssbo);
@@ -414,7 +476,45 @@ void SPHFluidGPU::DispatchCompute(float overrideDt) {
     glDispatchCompute((particles.size() + 255) / 256, 1, 1);
     glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
 
+    // 5) River mode: terrain collision + particle recycling
+    if (riverMode && !terrainHeights.empty()) {
+        DispatchTerrainConstraints();
+        DispatchStreamEmit();
+    }
+
     glUseProgram(0);
+}
+
+void SPHFluidGPU::DispatchTerrainConstraints() {
+    if (!terrainConstraintShader || !terrainSSBO) return;
+
+    glUseProgram(terrainConstraintShader);
+    glUniform1i(glGetUniformLocation(terrainConstraintShader, "numParticles"), int(particles.size()));
+    glUniform2i(glGetUniformLocation(terrainConstraintShader, "terrainGrid"),  terrainW, terrainH);
+    glUniform2f(glGetUniformLocation(terrainConstraintShader, "terrainMin"),   terrainWorldMinX, terrainWorldMinZ);
+    glUniform2f(glGetUniformLocation(terrainConstraintShader, "terrainSize"),  terrainWorldSizeX, terrainWorldSizeZ);
+    glUniform1f(glGetUniformLocation(terrainConstraintShader, "terrainRestitution"), 0.1f);
+    glUniform1f(glGetUniformLocation(terrainConstraintShader, "terrainFriction"),    0.35f);
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, ssbo);
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 7, terrainSSBO);
+    glDispatchCompute((particles.size() + 255) / 256, 1, 1);
+    glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
+}
+
+void SPHFluidGPU::DispatchStreamEmit() {
+    if (!streamEmitShader) return;
+
+    glUseProgram(streamEmitShader);
+    glUniform1i(glGetUniformLocation(streamEmitShader, "numParticles"),  int(particles.size()));
+    glUniform1f(glGetUniformLocation(streamEmitShader, "sinkY"),         riverSinkY);
+    glUniform1f(glGetUniformLocation(streamEmitShader, "sinkZMax"),      riverSinkZMax);
+    glUniform3f(glGetUniformLocation(streamEmitShader, "emitterPos"),    riverEmitterPos.x, riverEmitterPos.y, riverEmitterPos.z);
+    glUniform3f(glGetUniformLocation(streamEmitShader, "emitterVel"),    riverEmitterVel.x, riverEmitterVel.y, riverEmitterVel.z);
+    glUniform1f(glGetUniformLocation(streamEmitShader, "emitterRadius"), riverEmitterRadius);
+    glUniform1f(glGetUniformLocation(streamEmitShader, "restDensity"),   param_restDensity);
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, ssbo);
+    glDispatchCompute((particles.size() + 255) / 256, 1, 1);
+    glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
 }
 
 GLuint SPHFluidGPU::GetFluidVBO() const { return fluidVBO; }
@@ -533,4 +633,99 @@ GLuint SPHFluidGPU::LoadComputeShader(const char* filePath) {
         Debug::FatalError("Compute link failed:\n" + log, __FILE__, __LINE__);
     }
     return prog;
+}
+
+// ---------------------------------------------------------------------------
+// River / terrain generation
+// ---------------------------------------------------------------------------
+
+void SPHFluidGPU::GenerateRiverTerrain(int seed) {
+    std::srand(static_cast<unsigned>(seed));
+    auto frand = []() { return std::rand() / float(RAND_MAX); };
+
+    // Randomised river channel parameters
+    riverAmp          = 1.5f + frand() * 2.5f;     // meander amplitude
+    riverFreq         = 0.15f + frand() * 0.20f;   // meander frequency
+    riverPhase        = frand() * 6.2831f;
+    riverChannelWidth = 2.5f + frand() * 2.0f;
+    float channelDepth = 1.2f + frand() * 1.5f;    // how deep the channel is carved
+    float slopeDrop    = 4.0f + frand() * 4.0f;    // terrain drop from upstream to downstream
+
+    // Noise phase seeds for the surrounding terrain
+    float ph[8];
+    for (int k = 0; k < 8; ++k) ph[k] = frand() * 6.2831f;
+
+    // Match terrain footprint to simulation box (elongated for river)
+    terrainWorldMinX  = param_boxCenter.x - param_boxHalf.x;
+    terrainWorldMinZ  = param_boxCenter.z - param_boxHalf.z;
+    terrainWorldSizeX = 2.0f * param_boxHalf.x;
+    terrainWorldSizeZ = 2.0f * param_boxHalf.z;
+
+    float xMin   = terrainWorldMinX;
+    float zMin   = terrainWorldMinZ;
+    float xSize  = terrainWorldSizeX;
+    float zSize  = terrainWorldSizeZ;
+    float yBase  = param_boxCenter.y - param_boxHalf.y; // box floor in world Y
+
+    terrainHeights.resize(terrainW * terrainH);
+
+    for (int iz = 0; iz < terrainH; ++iz) {
+        for (int ix = 0; ix < terrainW; ++ix) {
+            float wx = xMin + (float(ix) / float(terrainW - 1)) * xSize;
+            float wz = zMin + (float(iz) / float(terrainH - 1)) * zSize;
+
+            // Normalized downstream position [0,1]
+            float tFlow = (wz - zMin) / zSize;
+
+            // River centerline sinusoidal path (in X)
+            float centerX = param_boxCenter.x + riverAmp * std::sinf(riverFreq * wz + riverPhase);
+            float distToRiver = std::fabsf(wx - centerX);
+
+            // Background terrain from stacked sine noise
+            float h = yBase + 2.5f;
+            h += 1.2f * std::sinf(wx * 0.40f + ph[0]) * std::cosf(wz * 0.30f + ph[1]);
+            h += 0.70f * std::sinf(wx * 0.80f + ph[2]) * std::sinf(wz * 0.70f + ph[3]);
+            h += 0.35f * std::sinf(wx * 1.50f + ph[4]) * std::cosf(wz * 1.30f + ph[5]);
+            h += 0.18f * std::sinf(wx * 2.60f + ph[6]) * std::sinf(wz * 2.20f + ph[7]);
+
+            // River floor slopes downhill (tFlow=0 → upstream, tFlow=1 → downstream)
+            float riverFloor = yBase + 1.0f - tFlow * slopeDrop;
+
+            // Carve parabolic channel cross-section
+            if (distToRiver < riverChannelWidth) {
+                float u = distToRiver / riverChannelWidth; // 0=centre, 1=bank
+                float carved = riverFloor + channelDepth * u * u;
+                h = std::min(h, carved);
+            }
+
+            // Don't punch through the box floor
+            h = std::max(h, yBase - 0.3f);
+
+            terrainHeights[iz * terrainW + ix] = h;
+        }
+    }
+
+    // Position emitter at the upstream mouth of the channel
+    float startX = param_boxCenter.x + riverAmp * std::sinf(riverPhase);
+    riverEmitterPos    = Vec3(startX, yBase + 2.5f, zMin + 0.4f);
+    riverEmitterVel    = Vec3(0.0f, -0.3f, 4.0f);   // launch into the channel
+    riverEmitterRadius = riverChannelWidth * 0.35f;
+    riverSinkY         = yBase - 1.5f;               // below terrain floor
+    riverSinkZMax      = param_boxCenter.z + param_boxHalf.z - 0.5f; // at downstream edge
+
+    // Gravity: mostly downward, gentle push along +Z for river flow
+    param_gravityY = -400.0f;   // reduced to keep water in shallow channel
+    param_gravityZ =  120.0f;   // push along river direction
+
+    // Upload heightfield to GPU
+    if (terrainSSBO == 0) glGenBuffers(1, &terrainSSBO);
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, terrainSSBO);
+    glBufferData(GL_SHADER_STORAGE_BUFFER,
+                 terrainHeights.size() * sizeof(float),
+                 terrainHeights.data(), GL_STATIC_DRAW);
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
+
+    std::cout << "[River] seed=" << seed
+              << " amp=" << riverAmp << " freq=" << riverFreq
+              << " width=" << riverChannelWidth << " slope=" << slopeDrop << "\n";
 }

--- a/ComponentFramework/SPHFluid3D.h
+++ b/ComponentFramework/SPHFluid3D.h
@@ -87,6 +87,8 @@ public:
     float param_gasConstant = 2000.0f;
     float param_viscosity = 3.5f;
     float param_gravityY = -980.0f;
+    float param_gravityX = 0.0f;
+    float param_gravityZ = 0.0f;
     float param_surfaceTension = 0.0728f;
     float param_timeStep = 0.001f;
     bool  param_pause = false;
@@ -102,6 +104,39 @@ public:
     Vec3  param_boxEulerDeg = Vec3(0, 0, 0);
     float param_wallRestitution = 0.15f;
     float param_wallFriction = 0.02f;
+
+    // --- River / Stream mode ---
+    bool  riverMode = false;
+
+    // Terrain heightfield (CPU copy; GPU SSBO at binding 7)
+    std::vector<float> terrainHeights;
+    int   terrainW          = 64;
+    int   terrainH          = 64;
+    float terrainWorldMinX  = -7.0f;
+    float terrainWorldMinZ  = -10.0f;
+    float terrainWorldSizeX = 14.0f;
+    float terrainWorldSizeZ = 20.0f;
+
+    // Emitter / sink parameters (set by GenerateRiverTerrain)
+    Vec3  riverEmitterPos    = Vec3(0,  3.0f, -9.0f);
+    Vec3  riverEmitterVel    = Vec3(0, -0.5f,  4.0f);
+    float riverEmitterRadius = 1.5f;
+    float riverSinkY         = -8.5f;
+    float riverSinkZMax      =  9.0f;
+
+    // Stored per-generation values (used during InitializeParticles)
+    float riverAmp   = 2.0f;
+    float riverFreq  = 0.25f;
+    float riverPhase = 0.0f;
+    float riverChannelWidth = 3.0f;
+
+    GLuint terrainSSBO           = 0;
+    GLuint terrainConstraintShader = 0;
+    GLuint streamEmitShader        = 0;
+
+    void GenerateRiverTerrain(int seed);
+    void DispatchTerrainConstraints();
+    void DispatchStreamEmit();
 
 private:
     GLuint LoadComputeShader(const char* filePath);

--- a/ComponentFramework/Scene0p.cpp
+++ b/ComponentFramework/Scene0p.cpp
@@ -94,6 +94,12 @@ bool Scene0p::OnCreate() {
     glGenVertexArrays(1, &ssfrQuadVAO);
     glEnable(GL_PROGRAM_POINT_SIZE);
 
+    terrainShader = new Shader("shaders/terrainVert.glsl", "shaders/terrainFrag.glsl");
+    if (!terrainShader->OnCreate()) { std::cerr << "terrain shader failed\n"; return false; }
+    glGenVertexArrays(1, &terrainVAO);
+    glGenBuffers(1, &terrainVBO);
+    glGenBuffers(1, &terrainEBO);
+
     {
         GLint vp[4] = {0,0,0,0};
         glGetIntegerv(GL_VIEWPORT, vp);
@@ -130,6 +136,10 @@ void Scene0p::OnDestroy() {
     if (ssfrCompositeShader) { ssfrCompositeShader->OnDestroy(); delete ssfrCompositeShader; ssfrCompositeShader = nullptr; }
     if (ssfrQuadVAO)         glDeleteVertexArrays(1, &ssfrQuadVAO);
     DestroySSFRBuffers();
+    if (terrainShader) { terrainShader->OnDestroy(); delete terrainShader; terrainShader = nullptr; }
+    if (terrainVAO) glDeleteVertexArrays(1, &terrainVAO);
+    if (terrainVBO) glDeleteBuffers(1, &terrainVBO);
+    if (terrainEBO) glDeleteBuffers(1, &terrainEBO);
 }
 
 void Scene0p::HandleEvents(const SDL_Event& e) {
@@ -322,6 +332,37 @@ void Scene0p::Update(const float deltaTime) {
     ImGui::DragFloat("Range Min", &vizRangeMin, 0.1f);
     ImGui::DragFloat("Range Max", &vizRangeMax, 0.1f);
     ImGui::TextDisabled("Height mode ignores Range Min/Max and uses box Y extents.");
+
+    ImGui::Separator();
+    if (ImGui::CollapsingHeader("River / Stream Mode")) {
+        bool wasRiver = fluidGPU->riverMode;
+        ImGui::Checkbox("Enable River Mode", &fluidGPU->riverMode);
+        ImGui::SliderInt("River Seed", &riverSeed, 1, 999);
+        if (ImGui::Button("Generate New River")) {
+            if (!fluidGPU->riverMode) fluidGPU->riverMode = true;
+            // Elongate box in Z for a longer channel
+            fluidGPU->param_boxHalf = Vec3(7.0f, 8.0f, 10.0f);
+            fluidGPU->param_boxCenter = Vec3(0.0f, 0.0f, 0.0f);
+            fluidGPU->param_boxEulerDeg = Vec3(0, 0, 0);
+            fluidGPU->GenerateRiverTerrain(riverSeed);
+            BuildTerrainMesh();
+            pendingReset = true;
+        }
+        if (fluidGPU->riverMode) {
+            ImGui::Text("Emitter: (%.1f, %.1f, %.1f)", fluidGPU->riverEmitterPos.x, fluidGPU->riverEmitterPos.y, fluidGPU->riverEmitterPos.z);
+            ImGui::SliderFloat("Emitter vel Z", &fluidGPU->riverEmitterVel.z, 0.0f, 15.0f);
+            ImGui::SliderFloat("Gravity Z (flow)", &fluidGPU->param_gravityZ, 0.0f, 400.0f);
+            ImGui::SliderFloat("Gravity Y",         &fluidGPU->param_gravityY, -980.0f, -50.0f);
+        }
+        if (!fluidGPU->riverMode && wasRiver) {
+            // Restore box to default when river mode is turned off
+            fluidGPU->param_boxHalf = Vec3(7, 7, 7);
+            fluidGPU->param_boxCenter = Vec3(0, 0, 0);
+            fluidGPU->param_gravityY = -980.0f;
+            fluidGPU->param_gravityZ =    0.0f;
+            pendingReset = true;
+        }
+    }
 
     ImGui::Separator();
     if (ImGui::CollapsingHeader("Water Rendering", ImGuiTreeNodeFlags_DefaultOpen)) {
@@ -676,15 +717,30 @@ void Scene0p::RenderSSFR() const {
     glDrawArrays(GL_POINTS, 0, nFluid);
 
     // -----------------------------------------------------------------------
-    // Pass 4 — Background scene (box wireframe on black sky)
+    // Pass 4 — Background scene (terrain + box wireframe on sky)
     // -----------------------------------------------------------------------
     glBindFramebuffer(GL_FRAMEBUFFER, ssfrBgFBO);
-    glClearColor(0.03f, 0.05f, 0.08f, 1.0f); // dark night sky
+    glClearColor(0.40f, 0.55f, 0.65f, 1.0f); // sky colour (nicer with terrain)
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     glEnable(GL_DEPTH_TEST);
+    glDepthFunc(GL_LESS);
     glDisable(GL_BLEND);
 
-    if (lineShader && boxVAO) {
+    // Terrain mesh (when river mode is active and terrain has been built)
+    if (terrainShader && terrainVAO && terrainIndexCount > 0 &&
+        fluidGPU && fluidGPU->riverMode) {
+        glUseProgram(terrainShader->GetProgram());
+        glUniformMatrix4fv(terrainShader->GetUniformID("projectionMatrix"), 1, GL_FALSE, projectionMatrix);
+        glUniformMatrix4fv(terrainShader->GetUniformID("viewMatrix"),       1, GL_FALSE, viewMatrix);
+        glUniform3fv(terrainShader->GetUniformID("sunDirWorld"), 1, sunDirWorld);
+        glUniform3fv(terrainShader->GetUniformID("sunColor"),    1, sunColor);
+        glBindVertexArray(terrainVAO);
+        glDrawElements(GL_TRIANGLES, terrainIndexCount, GL_UNSIGNED_INT, nullptr);
+        glBindVertexArray(0);
+    }
+
+    // Box wireframe (skip in river mode to reduce visual clutter)
+    if (lineShader && boxVAO && fluidGPU && !fluidGPU->riverMode) {
         glUseProgram(lineShader->GetProgram());
         glUniformMatrix4fv(lineShader->GetUniformID("projectionMatrix"), 1, GL_FALSE, projectionMatrix);
         glUniformMatrix4fv(lineShader->GetUniformID("viewMatrix"),       1, GL_FALSE, viewMatrix);
@@ -746,4 +802,74 @@ void Scene0p::RenderSSFR() const {
     glEnable(GL_DEPTH_TEST);
     glDisable(GL_BLEND);
     glActiveTexture(GL_TEXTURE0);
+}
+
+void Scene0p::BuildTerrainMesh() {
+    if (!fluidGPU || fluidGPU->terrainHeights.empty()) return;
+
+    const int W = fluidGPU->terrainW;
+    const int H = fluidGPU->terrainH;
+    const float xMin  = fluidGPU->terrainWorldMinX;
+    const float zMin  = fluidGPU->terrainWorldMinZ;
+    const float xSize = fluidGPU->terrainWorldSizeX;
+    const float zSize = fluidGPU->terrainWorldSizeZ;
+    const auto& ht    = fluidGPU->terrainHeights;
+
+    struct TV { float x, y, z, nx, ny, nz; };
+    std::vector<TV>       verts(W * H);
+    std::vector<uint32_t> idx;
+    idx.reserve((W - 1) * (H - 1) * 6);
+
+    float dx = xSize / float(W - 1);
+    float dz = zSize / float(H - 1);
+
+    for (int iz = 0; iz < H; ++iz) {
+        for (int ix = 0; ix < W; ++ix) {
+            float wx = xMin + ix * dx;
+            float wz = zMin + iz * dz;
+            float wy = ht[iz * W + ix];
+
+            // Finite-difference normal
+            float hR = (ix < W-1) ? ht[iz*W+(ix+1)] : wy;
+            float hL = (ix > 0)   ? ht[iz*W+(ix-1)] : wy;
+            float hF = (iz < H-1) ? ht[(iz+1)*W+ix] : wy;
+            float hB = (iz > 0)   ? ht[(iz-1)*W+ix] : wy;
+            float nx = (hL - hR) / (2.0f * dx);
+            float ny = 1.0f;
+            float nz = (hB - hF) / (2.0f * dz);
+            float len = std::sqrt(nx*nx + ny*ny + nz*nz);
+            if (len > 1e-6f) { nx/=len; ny/=len; nz/=len; }
+
+            verts[iz * W + ix] = {wx, wy, wz, nx, ny, nz};
+        }
+    }
+
+    for (int iz = 0; iz < H - 1; ++iz) {
+        for (int ix = 0; ix < W - 1; ++ix) {
+            uint32_t base = uint32_t(iz * W + ix);
+            idx.push_back(base);
+            idx.push_back(base + 1);
+            idx.push_back(base + W);
+            idx.push_back(base + 1);
+            idx.push_back(base + W + 1);
+            idx.push_back(base + W);
+        }
+    }
+    terrainIndexCount = int(idx.size());
+
+    glBindVertexArray(terrainVAO);
+
+    glBindBuffer(GL_ARRAY_BUFFER, terrainVBO);
+    glBufferData(GL_ARRAY_BUFFER, verts.size() * sizeof(TV), verts.data(), GL_STATIC_DRAW);
+
+    // position (loc=0), normal (loc=1)
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(TV), (void*)0);
+    glEnableVertexAttribArray(1);
+    glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, sizeof(TV), (void*)(3*sizeof(float)));
+
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, terrainEBO);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, idx.size() * sizeof(uint32_t), idx.data(), GL_STATIC_DRAW);
+
+    glBindVertexArray(0);
 }

--- a/ComponentFramework/Scene0p.h
+++ b/ComponentFramework/Scene0p.h
@@ -100,6 +100,18 @@ private:
     void    RenderSSFR() const;
     void    DestroySSFRBuffers();
 
+    // --- Terrain mesh ---
+    Shader* terrainShader     = nullptr;
+    GLuint  terrainVAO        = 0;
+    GLuint  terrainVBO        = 0;
+    GLuint  terrainEBO        = 0;
+    int     terrainIndexCount = 0;
+    void    BuildTerrainMesh();
+
+    // River generation UI state
+    int     riverSeed         = 1;
+    bool    pendingRiverRegen = false;
+
 public:
     explicit Scene0p();
     ~Scene0p() override;

--- a/ComponentFramework/shaders/StreamEmit.comp
+++ b/ComponentFramework/shaders/StreamEmit.comp
@@ -1,0 +1,49 @@
+#version 450
+layout(local_size_x = 256) in;
+
+struct Particle {
+    vec4 pos; vec4 vel; vec4 acc;
+    float density; float pressure; float padA; float padB;
+    ivec4 flags;
+};
+layout(std430, binding=0) buffer ParticleBuf { Particle particles[]; };
+
+uniform int   numParticles;
+uniform float sinkY;          // recycle if below this world Y
+uniform float sinkZMax;       // recycle if past this world Z (downstream)
+uniform vec3  emitterPos;     // respawn centre
+uniform vec3  emitterVel;     // initial velocity on respawn
+uniform float emitterRadius;  // XZ spread radius
+uniform float restDensity;
+
+void main() {
+    uint i = gl_GlobalInvocationID.x;
+    if (i >= uint(numParticles)) return;
+
+    Particle p = particles[i];
+    if (p.flags.x == 1) return; // keep ghost particles untouched
+
+    bool dead = (p.pos.y < sinkY) || (p.pos.z > sinkZMax);
+    if (!dead) return;
+
+    // LCG hash for deterministic but spread-out positions
+    uint seed = uint(i) * 1664525u + 1013904223u;
+    float r1 = float(seed & 0xFFFFu) / 65535.0;
+    seed = seed * 1664525u + 1013904223u;
+    float r2 = float(seed & 0xFFFFu) / 65535.0;
+    seed = seed * 1664525u + 1013904223u;
+    float r3 = float(seed & 0xFFFFu) / 65535.0;
+
+    float angle  = r1 * 6.2831853;
+    float radius = sqrt(r2) * emitterRadius;
+
+    p.pos.x   = emitterPos.x + radius * cos(angle);
+    p.pos.y   = emitterPos.y + r3 * 0.4;
+    p.pos.z   = emitterPos.z + r2 * 0.4;
+    p.vel     = vec4(emitterVel, 0.0);
+    p.acc     = vec4(0.0);
+    p.density = restDensity;
+    p.pressure = 0.0;
+
+    particles[i] = p;
+}

--- a/ComponentFramework/shaders/TerrainConstraints.comp
+++ b/ComponentFramework/shaders/TerrainConstraints.comp
@@ -1,0 +1,81 @@
+#version 450
+layout(local_size_x = 256) in;
+
+struct Particle {
+    vec4 pos; vec4 vel; vec4 acc;
+    float density; float pressure; float padA; float padB;
+    ivec4 flags;
+};
+layout(std430, binding=0) buffer ParticleBuf { Particle particles[]; };
+layout(std430, binding=7) readonly buffer TerrainBuf { float terrainH[]; };
+
+uniform int   numParticles;
+uniform ivec2 terrainGrid;        // (W, H) cells
+uniform vec2  terrainMin;         // (xMin, zMin) world space
+uniform vec2  terrainSize;        // (xSize, zSize) world space
+uniform float terrainRestitution; // bounce coefficient
+uniform float terrainFriction;    // tangential friction
+
+// Bilinear height sample
+float sampleHeight(float wx, float wz) {
+    float u = (wx - terrainMin.x) / terrainSize.x * float(terrainGrid.x - 1);
+    float v = (wz - terrainMin.y) / terrainSize.y * float(terrainGrid.y - 1);
+    u = clamp(u, 0.0, float(terrainGrid.x - 2));
+    v = clamp(v, 0.0, float(terrainGrid.y - 2));
+    int ix = int(u), iz = int(v);
+    float fx = u - float(ix), fz = v - float(iz);
+    int W = terrainGrid.x;
+    float h00 = terrainH[ ix      +  iz      * W];
+    float h10 = terrainH[(ix + 1) +  iz      * W];
+    float h01 = terrainH[ ix      + (iz + 1) * W];
+    float h11 = terrainH[(ix + 1) + (iz + 1) * W];
+    return mix(mix(h00, h10, fx), mix(h01, h11, fx), fz);
+}
+
+// Finite-difference surface normal (outward = upward)
+vec3 terrainNormal(float wx, float wz) {
+    float dx = terrainSize.x / float(terrainGrid.x - 1);
+    float dz = terrainSize.y / float(terrainGrid.y - 1);
+    float hR = sampleHeight(wx + dx, wz);
+    float hL = sampleHeight(wx - dx, wz);
+    float hF = sampleHeight(wx, wz + dz);
+    float hB = sampleHeight(wx, wz - dz);
+    return normalize(vec3(hL - hR, 2.0 * dx, hB - hF));
+}
+
+void main() {
+    uint i = gl_GlobalInvocationID.x;
+    if (i >= uint(numParticles)) return;
+
+    Particle p = particles[i];
+    if (p.flags.x == 1) return; // skip ghosts
+
+    float wx = p.pos.x, wz = p.pos.z;
+
+    // Only resolve within terrain XZ footprint
+    if (wx < terrainMin.x || wx > terrainMin.x + terrainSize.x ||
+        wz < terrainMin.y || wz > terrainMin.y + terrainSize.y) {
+        return;
+    }
+
+    float ty = sampleHeight(wx, wz);
+
+    if (p.pos.y < ty) {
+        vec3 N = terrainNormal(wx, wz);
+
+        // Push particle above terrain surface
+        p.pos.y = ty + 0.001;
+
+        // Velocity response
+        vec3 v  = p.vel.xyz;
+        float vN = dot(v, N);
+        if (vN < 0.0) { // moving into terrain
+            vec3 vNormal   = vN * N;
+            vec3 vTangent  = v - vNormal;
+            p.vel.xyz = -terrainRestitution * vNormal
+                        + (1.0 - terrainFriction) * vTangent;
+        }
+    }
+
+    particles[i] = p;
+}

--- a/ComponentFramework/shaders/terrainFrag.glsl
+++ b/ComponentFramework/shaders/terrainFrag.glsl
@@ -1,0 +1,30 @@
+#version 450
+in vec3 vWorldPos;
+in vec3 vNorm;
+
+out vec4 outColor;
+
+uniform vec3 sunDirWorld;
+uniform vec3 sunColor;
+
+void main() {
+    float h = vWorldPos.y;
+
+    // Height-blended terrain colours
+    vec3 wetRock  = vec3(0.22, 0.19, 0.15);   // wet channel floor
+    vec3 dryRock  = vec3(0.42, 0.37, 0.30);   // rocky bank
+    vec3 soil     = vec3(0.34, 0.28, 0.20);   // earthy upper bank
+    vec3 grass    = vec3(0.20, 0.36, 0.13);   // high ground vegetation
+
+    // Normalise height to roughly [0,1] across a 6-unit vertical range
+    float t = clamp(h * 0.18 + 0.35, 0.0, 1.0);
+
+    vec3 color;
+    if      (t < 0.25) color = mix(wetRock, dryRock, t * 4.0);
+    else if (t < 0.55) color = mix(dryRock, soil,    (t - 0.25) * (1.0 / 0.30));
+    else               color = mix(soil,    grass,    (t - 0.55) * (1.0 / 0.45));
+
+    // Simple Lambertian + ambient
+    float NdotL = max(0.15, dot(normalize(vNorm), normalize(sunDirWorld)));
+    outColor = vec4(color * sunColor * NdotL, 1.0);
+}

--- a/ComponentFramework/shaders/terrainVert.glsl
+++ b/ComponentFramework/shaders/terrainVert.glsl
@@ -1,0 +1,14 @@
+#version 450
+layout(location=0) in vec3 aPos;
+layout(location=1) in vec3 aNorm;
+
+uniform mat4 projectionMatrix, viewMatrix;
+
+out vec3 vWorldPos;
+out vec3 vNorm;
+
+void main() {
+    vWorldPos = aPos;
+    vNorm     = aNorm;
+    gl_Position = projectionMatrix * viewMatrix * vec4(aPos, 1.0);
+}


### PR DESCRIPTION
## Summary

- **Screen-Space Fluid Rendering (SSFR)**: 5-pass pipeline that converts SPH particles into a smooth, photorealistic water surface — sphere-impostor depth pass, bilateral depth smoothing, thickness accumulation, background capture, and final composite with Fresnel reflections, Blinn-Phong specular, refraction, and Beer-Lambert colour absorption
- **Procedural river/stream simulation**: seed-driven terrain generation (sine-wave noise + carved sinusoidal channel), GPU terrain collision shader, particle recycler for continuous flow, 3D gravity support, and a rendered terrain mesh with height-blended colours
- **ImGui controls**: "Water Rendering" panel (toggle, smooth iterations, filter radius, extinction, sun direction/colour, specular, refraction) and "River / Stream Mode" panel (seed, gravity, emitter/sink params, regenerate button)

## New shaders

| Shader | Purpose |
|--------|---------|
| `fluidDepth.vert/frag` | Sphere impostor — reconstructs true sphere depth via `gl_PointCoord` |
| `screenQuad.vert` | Fullscreen triangle (no buffer needed) |
| `depthSmooth.frag` | Separable bilateral Gaussian depth filter (ping-pong, N iterations) |
| `fluidThickness.frag` | Additive Gaussian blob per particle for thickness map |
| `fluidComposite.frag` | Normal reconstruction, Fresnel, specular, refraction, Beer-Lambert tint |
| `TerrainConstraints.comp` | Bilinear heightfield sampling + finite-difference normals, resolves penetration |
| `StreamEmit.comp` | Recycles sink particles back to emitter for continuous river flow |
| `terrainVert/Frag.glsl` | Terrain mesh with height-blended colour (wet rock → grass) |

## Test plan

- [ ] Build and run — no shader compile errors in console
- [ ] Enable "Water Surface Rendering" — particles replaced by smooth blue-green surface
- [ ] Move camera to grazing angle — Fresnel rim brightens
- [ ] Check specular highlight tracks sun direction
- [ ] Background box wireframe faintly visible through shallow water (refraction)
- [ ] Increase smooth iterations → surface becomes smoother
- [ ] Toggle water rendering off → original particle rendering unchanged
- [ ] Open "River / Stream Mode", click Regenerate with different seeds → different channel shapes
- [ ] Water flows down the channel and recycles at sink (continuous stream)
- [ ] Terrain mesh visible with height-blended colours

https://claude.ai/code/session_01Go9qCcRduJaYgAo1duxc2z