### PR TITLE
Make fluid follow the sinusoidal river meander with channel constraint shader

### DIFF
--- a/ComponentFramework/SPHFluid3D.cpp
+++ b/ComponentFramework/SPHFluid3D.cpp
@@ -38,8 +38,9 @@ SPHFluidGPU::SPHFluidGPU(size_t numParticles_)
     radixSortShader = LoadComputeShader("shaders/RadixSort.comp");
     obbConstraintShader = LoadComputeShader("shaders/OBBConstraints.comp");
     waveImpulseShader = LoadComputeShader("shaders/WaveImpulse.comp");
-    terrainConstraintShader = LoadComputeShader("shaders/TerrainConstraints.comp");
-    streamEmitShader = LoadComputeShader("shaders/StreamEmit.comp");
+    terrainConstraintShader  = LoadComputeShader("shaders/TerrainConstraints.comp");
+    streamEmitShader         = LoadComputeShader("shaders/StreamEmit.comp");
+    channelConstraintShader  = LoadComputeShader("shaders/ChannelConstraint.comp");
 
     // 1) Build particle array (also sets 'box' from OBB half)
     InitializeParticles();
@@ -68,9 +69,10 @@ SPHFluidGPU::~SPHFluidGPU() {
     glDeleteProgram(radixSortShader);
     glDeleteProgram(obbConstraintShader);
     glDeleteProgram(waveImpulseShader);
-    if (terrainConstraintShader) glDeleteProgram(terrainConstraintShader);
-    if (streamEmitShader)        glDeleteProgram(streamEmitShader);
-    if (terrainSSBO)             glDeleteBuffers(1, &terrainSSBO);
+    if (terrainConstraintShader)  glDeleteProgram(terrainConstraintShader);
+    if (streamEmitShader)         glDeleteProgram(streamEmitShader);
+    if (channelConstraintShader)  glDeleteProgram(channelConstraintShader);
+    if (terrainSSBO)              glDeleteBuffers(1, &terrainSSBO);
 }
 
 void SPHFluidGPU::InitializeParticles() {
@@ -127,7 +129,7 @@ void SPHFluidGPU::InitializeParticles() {
                 for (float wy = ty + spacing; wy <= ty + 2.5f && count < (int)numParticles; wy += spacing) {
                     SPHParticle p{};
                     p.pos = Vec4(wx + j(), wy + j(), wz + j(), 0.0f);
-                    p.vel = Vec4(0, 0, 1.5f, 0); // initial downstream velocity
+                    p.vel = Vec4(0, 0, 0.5f, 0); // channel constraint drives flow
                     p.acc = Vec4(0, 0, 0, 0);
                     p.density = p.pressure = 0.0f;
                     p.isGhost = 0; p.isActive = 0; p.pad0 = 0;
@@ -476,9 +478,10 @@ void SPHFluidGPU::DispatchCompute(float overrideDt) {
     glDispatchCompute((particles.size() + 255) / 256, 1, 1);
     glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
 
-    // 5) River mode: terrain collision + particle recycling
+    // 5) River mode: terrain collision, channel confinement, particle recycling
     if (riverMode && !terrainHeights.empty()) {
         DispatchTerrainConstraints();
+        DispatchChannelConstraint();
         DispatchStreamEmit();
     }
 
@@ -497,6 +500,23 @@ void SPHFluidGPU::DispatchTerrainConstraints() {
     glUniform1f(glGetUniformLocation(terrainConstraintShader, "terrainFriction"),    0.05f);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, ssbo);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 7, terrainSSBO);
+    glDispatchCompute((particles.size() + 255) / 256, 1, 1);
+    glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
+}
+
+void SPHFluidGPU::DispatchChannelConstraint() {
+    if (!channelConstraintShader) return;
+
+    glUseProgram(channelConstraintShader);
+    glUniform1i(glGetUniformLocation(channelConstraintShader, "numParticles"),  int(particles.size()));
+    glUniform1f(glGetUniformLocation(channelConstraintShader, "boxCenterX"),    param_boxCenter.x);
+    glUniform1f(glGetUniformLocation(channelConstraintShader, "riverAmp"),      riverAmp);
+    glUniform1f(glGetUniformLocation(channelConstraintShader, "riverFreq"),     riverFreq);
+    glUniform1f(glGetUniformLocation(channelConstraintShader, "riverPhase"),    riverPhase);
+    glUniform1f(glGetUniformLocation(channelConstraintShader, "channelWidth"),  riverChannelWidth);
+    glUniform1f(glGetUniformLocation(channelConstraintShader, "flowGravity"),   40.0f);
+    glUniform1f(glGetUniformLocation(channelConstraintShader, "timeStep"),      param_timeStep);
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, ssbo);
     glDispatchCompute((particles.size() + 255) / 256, 1, 1);
     glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
 }
@@ -709,15 +729,14 @@ void SPHFluidGPU::GenerateRiverTerrain(int seed) {
     // Position emitter at the upstream mouth of the channel
     float startX = param_boxCenter.x + riverAmp * std::sinf(riverPhase);
     riverEmitterPos    = Vec3(startX, yBase + 2.5f, zMin + 0.4f);
-    riverEmitterVel    = Vec3(0.0f, -0.5f, 1.5f);   // gentle launch — slope drives the rest
+    riverEmitterVel    = Vec3(0.0f, -0.5f, 0.5f);   // channel constraint steers flow
     riverEmitterRadius = riverChannelWidth * 0.35f;
     riverSinkY         = yBase + 0.3f;               // just above box floor — recycled when they hit bottom
     riverSinkZMax      = param_boxCenter.z + param_boxHalf.z - 0.5f; // at downstream edge
 
-    // Gentle Z push — slope does most of the work; high Z gravity causes
-    // particles to accelerate to a trickle at the downstream end
+    // Channel constraint handles flow along the meander; no straight Z gravity needed
     param_gravityY = -120.0f;
-    param_gravityZ =  25.0f;
+    param_gravityZ =   0.0f;
 
     // Upload heightfield to GPU
     if (terrainSSBO == 0) glGenBuffers(1, &terrainSSBO);

--- a/ComponentFramework/SPHFluid3D.h
+++ b/ComponentFramework/SPHFluid3D.h
@@ -130,13 +130,15 @@ public:
     float riverPhase = 0.0f;
     float riverChannelWidth = 3.0f;
 
-    GLuint terrainSSBO           = 0;
+    GLuint terrainSSBO             = 0;
     GLuint terrainConstraintShader = 0;
     GLuint streamEmitShader        = 0;
+    GLuint channelConstraintShader = 0;
 
     void GenerateRiverTerrain(int seed);
     void DispatchTerrainConstraints();
     void DispatchStreamEmit();
+    void DispatchChannelConstraint();
 
 private:
     GLuint LoadComputeShader(const char* filePath);

--- a/ComponentFramework/shaders/ChannelConstraint.comp
+++ b/ComponentFramework/shaders/ChannelConstraint.comp
@@ -1,0 +1,51 @@
+#version 450
+layout(local_size_x = 256) in;
+
+struct Particle {
+    vec4 pos; vec4 vel; vec4 acc;
+    float density; float pressure; float padA; float padB;
+    ivec4 flags;
+};
+layout(std430, binding=0) buffer ParticleBuf { Particle particles[]; };
+
+uniform int   numParticles;
+uniform float boxCenterX;      // param_boxCenter.x
+uniform float riverAmp;        // meander amplitude
+uniform float riverFreq;       // meander frequency
+uniform float riverPhase;      // meander phase
+uniform float channelWidth;    // half-width of channel (hard wall)
+uniform float flowGravity;     // acceleration along channel tangent (units/s^2)
+uniform float timeStep;
+
+void main() {
+    uint i = gl_GlobalInvocationID.x;
+    if (i >= uint(numParticles)) return;
+
+    Particle p = particles[i];
+    if (p.flags.x == 1) return; // leave ghost particles alone
+
+    float wz = p.pos.z;
+
+    // Channel centreline at this Z (matches GenerateRiverTerrain formula)
+    float cx  = boxCenterX + riverAmp * sin(riverFreq * wz + riverPhase);
+
+    // Channel tangent = d(centerX)/dz in the XZ plane, normalised
+    float tdx  = riverAmp * riverFreq * cos(riverFreq * wz + riverPhase);
+    float tlen = sqrt(tdx * tdx + 1.0);
+    vec2  tangXZ = vec2(tdx, 1.0) / tlen; // (X, Z) components
+
+    // Apply gravitational acceleration along the channel tangent.
+    // This replaces the uniform param_gravityZ and steers particles
+    // around bends rather than straight ahead.
+    p.vel.x += tangXZ.x * flowGravity * timeStep;
+    p.vel.z += tangXZ.y * flowGravity * timeStep;
+
+    // Hard lateral channel walls — position correction + kill outward velocity
+    float dx = p.pos.x - cx;
+    if (abs(dx) > channelWidth) {
+        p.pos.x = cx + sign(dx) * channelWidth;
+        if (dx * p.vel.x > 0.0) p.vel.x = 0.0; // inelastic: water doesn't bounce sideways
+    }
+
+    particles[i] = p;
+}


### PR DESCRIPTION
## Problem
The fluid condensed into a straight vertical strip and ignored the sinusoidal meander shape. The bank lines showed the correct curved path but the water didn't follow it.

**Root cause**: `param_gravityZ` pushed all particles uniformly in the +Z direction regardless of where the channel bends. Particles naturally drifted to the path of least resistance (straight down the middle) rather than following the curved channel walls.

## Fix: `ChannelConstraint.comp`

A new GPU compute shader that runs each simulation step after terrain collision:

**1. Tangent-following gravity**
At each particle's Z position, compute the channel tangent:
```glsl
float tdx  = riverAmp * riverFreq * cos(riverFreq * wz + riverPhase);
vec2  tangXZ = normalize(vec2(tdx, 1.0));
p.vel += vec3(tangXZ.x, 0, tangXZ.y) * flowGravity * timeStep;
```
This replaces the uniform `param_gravityZ` — acceleration now steers *around bends* instead of pointing straight.

**2. Hard lateral channel walls**
```glsl
if (abs(dx) > channelWidth) {
    p.pos.x = cx + sign(dx) * channelWidth;
    if (dx * p.vel.x > 0.0) p.vel.x = 0.0;
}
```
Particles that escape the bank lines get snapped back and their outward velocity is killed.

`param_gravityZ` is now `0` — all flow steering comes from the channel tangent.

## Test plan
- [ ] Click Generate New River — water should follow the sinusoidal meander, not go straight
- [ ] Red bank lines should contain the water (no particles outside them)
- [ ] Different seeds produce different meander shapes that the water follows
- [ ] Channel stays full end-to-end

https://claude.ai/code/session_01Go9qCcRduJaYgAo1duxc2z