### PR TITLE
Fix fluid meander: proper terrain walls, channel-aware spawn, strong spring

### DIFF
--- a/ComponentFramework/SPHFluid3D.cpp
+++ b/ComponentFramework/SPHFluid3D.cpp
@@ -514,7 +514,7 @@ void SPHFluidGPU::DispatchChannelConstraint() {
     glUniform1f(glGetUniformLocation(channelConstraintShader, "riverFreq"),     riverFreq);
     glUniform1f(glGetUniformLocation(channelConstraintShader, "riverPhase"),    riverPhase);
     glUniform1f(glGetUniformLocation(channelConstraintShader, "channelWidth"),  riverChannelWidth);
-    glUniform1f(glGetUniformLocation(channelConstraintShader, "flowGravity"),   40.0f);
+    glUniform1f(glGetUniformLocation(channelConstraintShader, "flowGravity"),   80.0f);
     glUniform1f(glGetUniformLocation(channelConstraintShader, "timeStep"),      param_timeStep);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, ssbo);
     glDispatchCompute((particles.size() + 255) / 256, 1, 1);
@@ -533,6 +533,10 @@ void SPHFluidGPU::DispatchStreamEmit() {
     glUniform1f(glGetUniformLocation(streamEmitShader, "emitterRadius"),  riverEmitterRadius);
     glUniform1f(glGetUniformLocation(streamEmitShader, "emitterSpreadZ"), riverSinkZMax - riverEmitterPos.z);
     glUniform1f(glGetUniformLocation(streamEmitShader, "restDensity"),    param_restDensity);
+    glUniform1f(glGetUniformLocation(streamEmitShader, "boxCenterX"),     param_boxCenter.x);
+    glUniform1f(glGetUniformLocation(streamEmitShader, "riverAmp"),       riverAmp);
+    glUniform1f(glGetUniformLocation(streamEmitShader, "riverFreq"),      riverFreq);
+    glUniform1f(glGetUniformLocation(streamEmitShader, "riverPhase"),     riverPhase);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, ssbo);
     glDispatchCompute((particles.size() + 255) / 256, 1, 1);
     glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
@@ -669,7 +673,7 @@ void SPHFluidGPU::GenerateRiverTerrain(int seed) {
     riverFreq         = 0.15f + frand() * 0.20f;   // meander frequency
     riverPhase        = frand() * 6.2831f;
     riverChannelWidth = 2.5f + frand() * 2.0f;
-    float channelDepth = 1.2f + frand() * 1.5f;    // how deep the channel is carved
+    float channelDepth = 3.0f + frand() * 1.0f;    // deep channel so walls have real height
     float slopeDrop    = 0.6f + frand() * 0.8f;    // terrain drop: keep inside box bounds
 
     // Noise phase seeds for the surrounding terrain
@@ -713,10 +717,17 @@ void SPHFluidGPU::GenerateRiverTerrain(int seed) {
             float riverFloor = yBase + 1.0f - tFlow * slopeDrop;
 
             // Carve parabolic channel cross-section
+            float channelEdge = riverFloor + channelDepth; // height at bank top
             if (distToRiver < riverChannelWidth) {
                 float u = distToRiver / riverChannelWidth; // 0=centre, 1=bank
-                float carved = riverFloor + channelDepth * u * u;
-                h = std::min(h, carved);
+                h = riverFloor + channelDepth * u * u;     // set exactly, don't min
+            } else {
+                // Outside channel: raise terrain to create a genuine physical wall.
+                // Without this, noise dips can make the bank lower than the channel
+                // edge and the terrain constraint provides zero lateral containment.
+                float wallBase = channelEdge + 1.5f;
+                float pastBank = std::min((distToRiver - riverChannelWidth) * 1.5f, 2.0f);
+                h = std::max(h, wallBase + pastBank);
             }
 
             // Don't punch through the box floor

--- a/ComponentFramework/shaders/ChannelConstraint.comp
+++ b/ComponentFramework/shaders/ChannelConstraint.comp
@@ -9,12 +9,12 @@ struct Particle {
 layout(std430, binding=0) buffer ParticleBuf { Particle particles[]; };
 
 uniform int   numParticles;
-uniform float boxCenterX;      // param_boxCenter.x
-uniform float riverAmp;        // meander amplitude
-uniform float riverFreq;       // meander frequency
-uniform float riverPhase;      // meander phase
-uniform float channelWidth;    // half-width of channel (hard wall)
-uniform float flowGravity;     // acceleration along channel tangent (units/s^2)
+uniform float boxCenterX;
+uniform float riverAmp;
+uniform float riverFreq;
+uniform float riverPhase;
+uniform float channelWidth;
+uniform float flowGravity;   // acceleration along channel tangent
 uniform float timeStep;
 
 void main() {
@@ -22,29 +22,30 @@ void main() {
     if (i >= uint(numParticles)) return;
 
     Particle p = particles[i];
-    if (p.flags.x == 1) return; // leave ghost particles alone
+    if (p.flags.x == 1) return;
 
     float wz = p.pos.z;
-
-    // Channel centreline at this Z (matches GenerateRiverTerrain formula)
     float cx  = boxCenterX + riverAmp * sin(riverFreq * wz + riverPhase);
+    float dx  = p.pos.x - cx;
 
-    // Channel tangent = d(centerX)/dz in the XZ plane, normalised
+    // --- Tangent-following flow gravity ---
+    // Instead of a straight-Z push, accelerate along the channel curve tangent
     float tdx  = riverAmp * riverFreq * cos(riverFreq * wz + riverPhase);
     float tlen = sqrt(tdx * tdx + 1.0);
-    vec2  tangXZ = vec2(tdx, 1.0) / tlen; // (X, Z) components
+    vec2  tXZ  = vec2(tdx, 1.0) / tlen;
 
-    // Apply gravitational acceleration along the channel tangent.
-    // This replaces the uniform param_gravityZ and steers particles
-    // around bends rather than straight ahead.
-    p.vel.x += tangXZ.x * flowGravity * timeStep;
-    p.vel.z += tangXZ.y * flowGravity * timeStep;
+    p.vel.x += tXZ.x * flowGravity * timeStep;
+    p.vel.z += tXZ.y * flowGravity * timeStep;
 
-    // Hard lateral channel walls — position correction + kill outward velocity
-    float dx = p.pos.x - cx;
+    // --- Strong spring: pull particle toward channel centreline ---
+    // Large enough to overcome SPH pressure spreading (which is ~100-500 s^-2)
+    float spring = 3000.0;
+    p.vel.x -= dx * spring * timeStep;
+
+    // --- Hard lateral wall at channel boundary ---
     if (abs(dx) > channelWidth) {
         p.pos.x = cx + sign(dx) * channelWidth;
-        if (dx * p.vel.x > 0.0) p.vel.x = 0.0; // inelastic: water doesn't bounce sideways
+        if (dx * p.vel.x > 0.0) p.vel.x = 0.0;
     }
 
     particles[i] = p;

--- a/ComponentFramework/shaders/StreamEmit.comp
+++ b/ComponentFramework/shaders/StreamEmit.comp
@@ -9,25 +9,31 @@ struct Particle {
 layout(std430, binding=0) buffer ParticleBuf { Particle particles[]; };
 
 uniform int   numParticles;
-uniform float sinkY;          // recycle if below this world Y
-uniform float sinkZMax;       // recycle if past this world Z (downstream)
-uniform vec3  emitterPos;     // respawn centre (upstream)
-uniform vec3  emitterVel;     // initial velocity on respawn
-uniform float emitterRadius;  // XZ spread radius
-uniform float emitterSpreadZ; // how far downstream to spread recycled particles
+uniform float sinkY;
+uniform float sinkZMax;
+uniform vec3  emitterPos;
+uniform vec3  emitterVel;
+uniform float emitterRadius;
+uniform float emitterSpreadZ;
 uniform float restDensity;
+
+// River channel shape — needed to spawn at correct X for each Z
+uniform float boxCenterX;
+uniform float riverAmp;
+uniform float riverFreq;
+uniform float riverPhase;
 
 void main() {
     uint i = gl_GlobalInvocationID.x;
     if (i >= uint(numParticles)) return;
 
     Particle p = particles[i];
-    if (p.flags.x == 1) return; // keep ghost particles untouched
+    if (p.flags.x == 1) return;
 
     bool dead = (p.pos.y < sinkY) || (p.pos.z > sinkZMax);
     if (!dead) return;
 
-    // LCG hash for deterministic but spread-out positions
+    // LCG hash per particle index
     uint seed = uint(i) * 1664525u + 1013904223u;
     float r1 = float(seed & 0xFFFFu) / 65535.0;
     seed = seed * 1664525u + 1013904223u;
@@ -37,14 +43,15 @@ void main() {
     seed = seed * 1664525u + 1013904223u;
     float r4 = float(seed & 0xFFFFu) / 65535.0;
 
-    // Spread recycled particles along the full channel length so the
-    // river stays filled end-to-end rather than piling up at the emitter
-    float angle  = r4 * 6.2831853;
-    float radius = sqrt(r2) * emitterRadius;
+    // Choose Z anywhere along the channel
+    float spawnZ = emitterPos.z + r1 * emitterSpreadZ;
 
-    p.pos.x   = emitterPos.x + radius * cos(angle);
+    // Channel centreline at this Z — spawn X there, not at a fixed emitter X
+    float cx = boxCenterX + riverAmp * sin(riverFreq * spawnZ + riverPhase);
+
+    p.pos.x   = cx + (r4 - 0.5) * 2.0 * emitterRadius;
     p.pos.y   = emitterPos.y + r3 * 0.6;
-    p.pos.z   = emitterPos.z + r1 * emitterSpreadZ; // spread 0→full channel
+    p.pos.z   = spawnZ;
     p.vel     = vec4(emitterVel, 0.0);
     p.acc     = vec4(0.0);
     p.density = restDensity;


### PR DESCRIPTION
## Three root causes fixed

### 1. Terrain had no walls
The previous `std::min(h, carved)` carve only lowered terrain where the background noise was already high. In low-noise areas the "bank" had zero or negative height — the terrain outside the channel was actually *lower* than the channel edge, so the terrain constraint gave zero lateral push.

**Fix**: Inside the channel, set terrain exactly to the parabolic floor. Outside the channel, *raise* terrain to always be at least `channelEdge + 1.5` above the carved floor, with a further ramp of `+2` over the first unit past the bank. `channelDepth` increased to `3.0–4.0` (was `1.2–2.7`) so the walls now have genuine ~2.5-unit height.

### 2. Stream emit spawned at the wrong X
Recycled particles were placed at `emitterPos.x ± radius` regardless of the Z they were assigned. So every recycled particle respawned in a straight column at the upstream emitter X, undoing any lateral guidance.

**Fix**: `StreamEmit.comp` now computes `cx = boxCenterX + amp·sin(freq·spawnZ + phase)` and places each particle within `emitterRadius` of the correct channel centreline at its assigned Z.

### 3. Channel spring was too weak
`flowGravity = 40 units/s²` as a plain velocity impulse cannot overcome SPH pressure spreading forces (`~100–500 s⁻²`). The previous shader had no centering term at all.

**Fix**: `ChannelConstraint.comp` adds a `spring = 3000 s⁻²` restoring force (`-dx · spring · dt`) that actively pulls particles toward the centreline. `flowGravity` raised `40→80` for the tangent-direction steering.

## Test plan
- [ ] Click **Generate New River** — fluid should follow the sinusoidal meander matching the red bank lines
- [ ] No particles escape outside the red lines
- [ ] Different seeds produce different shapes the fluid follows
- [ ] Channel stays full end-to-end

https://claude.ai/code/session_01Go9qCcRduJaYgAo1duxc2z