### PR TITLE
Fix channel meander (direct position correction) + orbit/zoom/pan camera

### DIFF
--- a/ComponentFramework/Scene0p.cpp
+++ b/ComponentFramework/Scene0p.cpp
@@ -145,19 +145,81 @@ void Scene0p::OnDestroy() {
 }
 
 void Scene0p::HandleEvents(const SDL_Event& e) {
+    // Let ImGui consume mouse events first
+    bool imguiWantsMouse = ImGui::GetIO().WantCaptureMouse;
+
     switch (e.type) {
     case SDL_KEYDOWN:
         switch (e.key.keysym.scancode) {
-        case SDL_SCANCODE_W: cameraPos.y += 0.2f; break;
-        case SDL_SCANCODE_S: cameraPos.y -= 0.2f; break;
-        case SDL_SCANCODE_A: cameraPos.x -= 0.2f; break;
-        case SDL_SCANCODE_D: cameraPos.x += 0.2f; break;
-        case SDL_SCANCODE_R: cameraPos.z += 0.2f; break;
-        case SDL_SCANCODE_E: cameraPos.z -= 0.2f; break;
+        // Pan target with WASD/QE (unchanged)
+        case SDL_SCANCODE_W: cameraTarget.y += 0.3f; break;
+        case SDL_SCANCODE_S: cameraTarget.y -= 0.3f; break;
+        case SDL_SCANCODE_A: cameraTarget.x -= 0.3f; break;
+        case SDL_SCANCODE_D: cameraTarget.x += 0.3f; break;
+        case SDL_SCANCODE_Q: cameraTarget.z += 0.3f; break;
+        case SDL_SCANCODE_E: cameraTarget.z -= 0.3f; break;
         case SDL_SCANCODE_Z: drawInWireMode = !drawInWireMode; break;
+        // R resets to default view
+        case SDL_SCANCODE_R:
+            cameraTarget  = Vec3(0, 0, 0);
+            camDist       = 22.0f;
+            camAzimuth    = 0.0f;
+            camElevation  = 0.22f;
+            break;
         default: break;
         }
         break;
+
+    case SDL_MOUSEBUTTONDOWN:
+        if (!imguiWantsMouse) {
+            mouseButton = e.button.button;
+            mouseX = e.button.x;
+            mouseY = e.button.y;
+            mouseDown = true;
+        }
+        break;
+
+    case SDL_MOUSEBUTTONUP:
+        mouseDown = false;
+        mouseButton = -1;
+        break;
+
+    case SDL_MOUSEMOTION:
+        if (mouseDown && !imguiWantsMouse) {
+            int dx = e.motion.x - mouseX;
+            int dy = e.motion.y - mouseY;
+            mouseX = e.motion.x;
+            mouseY = e.motion.y;
+
+            if (mouseButton == SDL_BUTTON_LEFT) {
+                // Left drag — orbit
+                camAzimuth   -= dx * 0.005f;
+                camElevation += dy * 0.005f;
+                // Clamp elevation so camera doesn't flip over
+                const float maxEl = 1.55f; // ~89 degrees
+                if (camElevation >  maxEl) camElevation =  maxEl;
+                if (camElevation < -maxEl) camElevation = -maxEl;
+            } else if (mouseButton == SDL_BUTTON_RIGHT) {
+                // Right drag — pan target in the camera's right/up plane
+                float speed = camDist * 0.0015f;
+                // Camera right vector
+                float cosEl = std::cos(camElevation);
+                Vec3 right(std::cos(camAzimuth), 0.0f, -std::sin(camAzimuth));
+                Vec3 up(0.0f, 1.0f, 0.0f);
+                cameraTarget = cameraTarget - right * (dx * speed) + up * (dy * speed);
+            }
+        }
+        break;
+
+    case SDL_MOUSEWHEEL:
+        if (!imguiWantsMouse) {
+            // Scroll to zoom: exponential feel
+            camDist *= std::pow(0.90f, (float)e.wheel.y);
+            if (camDist < 1.0f)  camDist = 1.0f;
+            if (camDist > 120.0f) camDist = 120.0f;
+        }
+        break;
+
     default: break;
     }
 }
@@ -200,6 +262,16 @@ void Scene0p::Update(const float deltaTime) {
     ballAnimTime += deltaTime;
     float ballX = std::sin(ballAnimTime) * 3.0f;
     if (sphere) sphere->SetPosition(Vec3(ballX, 0.0f, 0.0f));
+
+    // Rebuild camera position from spherical orbit parameters
+    {
+        float cosEl = std::cos(camElevation);
+        float sinEl = std::sin(camElevation);
+        cameraPos = cameraTarget + Vec3(
+            std::sin(camAzimuth) * cosEl,
+            sinEl,
+            std::cos(camAzimuth) * cosEl) * camDist;
+    }
     viewMatrix = MMath::lookAt(cameraPos, cameraTarget, cameraUp);
 
     // Resize SSFR FBOs if viewport changed
@@ -350,6 +422,11 @@ void Scene0p::Update(const float deltaTime) {
             BuildTerrainMesh();
             BuildRiverBankLines();
             pendingReset = true;
+            // Auto-position camera for a clear river view
+            cameraTarget  = Vec3(fluidGPU->param_boxCenter.x, 0.0f, fluidGPU->param_boxCenter.z);
+            camDist       = 28.0f;
+            camAzimuth    = 0.0f;
+            camElevation  = 0.75f; // ~43 degrees — nice angled top-down
         }
         if (fluidGPU->riverMode) {
             ImGui::Text("Emitter: (%.1f, %.1f, %.1f)", fluidGPU->riverEmitterPos.x, fluidGPU->riverEmitterPos.y, fluidGPU->riverEmitterPos.z);

--- a/ComponentFramework/Scene0p.h
+++ b/ComponentFramework/Scene0p.h
@@ -25,9 +25,13 @@ private:
     bool    drawInWireMode = true;
     bool    mouseDown = false;
     int     mouseX = 0, mouseY = 0;
-    Vec3    cameraPos = Vec3(0.0f, 0.0f, 10.0f);
+    int     mouseButton = -1;       // -1=none, 1=left, 3=right
+    Vec3    cameraPos = Vec3(0.0f, 5.0f, 22.0f);
     Vec3    cameraTarget = Vec3(0.0f, 0.0f, 0.0f);
     Vec3    cameraUp = Vec3(0.0f, 1.0f, 0.0f);
+    float   camDist      = 22.0f;
+    float   camAzimuth   = 0.0f;   // radians, rotation around Y
+    float   camElevation = 0.22f;  // radians, pitch above horizon
 
     Shader* lineShader = nullptr;
     GLuint  boxVAO = 0, boxVBO = 0;

--- a/ComponentFramework/shaders/ChannelConstraint.comp
+++ b/ComponentFramework/shaders/ChannelConstraint.comp
@@ -14,7 +14,7 @@ uniform float riverAmp;
 uniform float riverFreq;
 uniform float riverPhase;
 uniform float channelWidth;
-uniform float flowGravity;   // acceleration along channel tangent
+uniform float flowGravity;
 uniform float timeStep;
 
 void main() {
@@ -28,24 +28,27 @@ void main() {
     float cx  = boxCenterX + riverAmp * sin(riverFreq * wz + riverPhase);
     float dx  = p.pos.x - cx;
 
-    // --- Tangent-following flow gravity ---
-    // Instead of a straight-Z push, accelerate along the channel curve tangent
+    // Tangent-following gravity — steer around bends
     float tdx  = riverAmp * riverFreq * cos(riverFreq * wz + riverPhase);
     float tlen = sqrt(tdx * tdx + 1.0);
     vec2  tXZ  = vec2(tdx, 1.0) / tlen;
-
     p.vel.x += tXZ.x * flowGravity * timeStep;
     p.vel.z += tXZ.y * flowGravity * timeStep;
 
-    // --- Strong spring: pull particle toward channel centreline ---
-    // Large enough to overcome SPH pressure spreading (which is ~100-500 s^-2)
-    float spring = 3000.0;
-    p.vel.x -= dx * spring * timeStep;
+    // Direct position correction toward centreline (unconditionally stable,
+    // analogous to terrain/OBB position snaps — no spring oscillation)
+    float corrRate = 0.20; // pull 20% of lateral error toward centre each step
+    p.pos.x -= dx * corrRate;
 
-    // --- Hard lateral wall at channel boundary ---
-    if (abs(dx) > channelWidth) {
-        p.pos.x = cx + sign(dx) * channelWidth;
-        if (dx * p.vel.x > 0.0) p.vel.x = 0.0;
+    // Kill velocity component pointing away from centreline
+    // so pressure forces can't continually drive particles outward
+    if (dx * p.vel.x > 0.0) p.vel.x *= 0.05;
+
+    // Hard wall at exact bank edge (absolute containment)
+    float dxNew = p.pos.x - cx;
+    if (abs(dxNew) > channelWidth) {
+        p.pos.x = cx + sign(dxNew) * channelWidth;
+        p.vel.x = 0.0;
     }
 
     particles[i] = p;


### PR DESCRIPTION
## Channel meander fix

**Root cause**: The spring force (`p.vel.x -= dx * 3000 * dt`) is a marginally-stable harmonic oscillator — particles oscillate left-right across the channel instead of converging. With eigenvalue magnitude exactly 1.0, there is no decay.

**Fix**: Replaced with a direct position correction — `p.pos.x -= dx * 0.20` each step. This is the same approach used by the terrain and OBB constraints. Error halves in ~3 steps, guaranteed convergent. Outward X velocity is also killed (multiplied by 0.05) so SPH pressure can't continuously push particles sideways against the correction.

## Camera improvements

| Control | Action |
|---------|--------|
| Left mouse drag | Orbit (azimuth + elevation, clamped to ±89°) |
| Right mouse drag | Pan camera target |
| Scroll wheel | Zoom (exponential, 1–120 unit range) |
| WASD / QE | Pan target |
| R | Reset to default view |
| Generate New River | Auto-positions to angled top-down river view |

Camera position is now rebuilt each frame from spherical coordinates `(camDist, camAzimuth, camElevation)` instead of being set by key increments.

## Test plan
- [ ] Generate New River — camera auto-positions to view the full channel
- [ ] Left-drag rotates around the scene; right-drag pans; scroll zooms
- [ ] Water follows the sinusoidal bank lines, not a straight column
- [ ] No particles escape outside the red bank lines

https://claude.ai/code/session_01Go9qCcRduJaYgAo1duxc2z