### PR TITLE
Rebuild terrain as plateau+channel, remove collapsing spring from constraint

### DIFF
--- a/ComponentFramework/SPHFluid3D.cpp
+++ b/ComponentFramework/SPHFluid3D.cpp
@@ -669,12 +669,12 @@ void SPHFluidGPU::GenerateRiverTerrain(int seed) {
     auto frand = []() { return std::rand() / float(RAND_MAX); };
 
     // Randomised river channel parameters
-    riverAmp          = 1.5f + frand() * 2.5f;     // meander amplitude
-    riverFreq         = 0.15f + frand() * 0.20f;   // meander frequency
+    riverAmp          = 0.5f + frand() * 1.5f;     // moderate meander — stays inside box
+    riverFreq         = 0.18f + frand() * 0.18f;
     riverPhase        = frand() * 6.2831f;
-    riverChannelWidth = 2.5f + frand() * 2.0f;
-    float channelDepth = 3.0f + frand() * 1.0f;    // deep channel so walls have real height
-    float slopeDrop    = 0.6f + frand() * 0.8f;    // terrain drop: keep inside box bounds
+    riverChannelWidth = 1.8f + frand() * 1.2f;     // 1.8-3.0 unit half-width
+    float channelDepth = 3.5f + frand() * 1.0f;    // deep U-shape: steep parabolic walls
+    float slopeDrop    = 0.3f + frand() * 0.5f;    // gentle downstream slope
 
     // Noise phase seeds for the surrounding terrain
     float ph[8];
@@ -706,28 +706,27 @@ void SPHFluidGPU::GenerateRiverTerrain(int seed) {
             float centerX = param_boxCenter.x + riverAmp * std::sinf(riverFreq * wz + riverPhase);
             float distToRiver = std::fabsf(wx - centerX);
 
-            // Background terrain from stacked sine noise
-            float h = yBase + 2.5f;
-            h += 1.2f * std::sinf(wx * 0.40f + ph[0]) * std::cosf(wz * 0.30f + ph[1]);
-            h += 0.70f * std::sinf(wx * 0.80f + ph[2]) * std::sinf(wz * 0.70f + ph[3]);
-            h += 0.35f * std::sinf(wx * 1.50f + ph[4]) * std::cosf(wz * 1.30f + ph[5]);
-            h += 0.18f * std::sinf(wx * 2.60f + ph[6]) * std::sinf(wz * 2.20f + ph[7]);
-
-            // River floor slopes downhill (tFlow=0 → upstream, tFlow=1 → downstream)
+            // River floor slopes gently downstream
             float riverFloor = yBase + 1.0f - tFlow * slopeDrop;
+            float channelEdge = riverFloor + channelDepth;
 
-            // Carve parabolic channel cross-section
-            float channelEdge = riverFloor + channelDepth; // height at bank top
+            // Flat plateau background with gentle rolling noise
+            // Plateau sits ABOVE the channel edge so the carved channel is visible
+            float plateau = yBase + 5.5f;
+            float h = plateau;
+            h += 0.5f * std::sinf(wx * 0.35f + ph[0]) * std::cosf(wz * 0.28f + ph[1]);
+            h += 0.25f * std::sinf(wx * 0.70f + ph[2]) * std::sinf(wz * 0.60f + ph[3]);
+            h += 0.12f * std::sinf(wx * 1.40f + ph[4]) * std::cosf(wz * 1.20f + ph[5]);
+
             if (distToRiver < riverChannelWidth) {
-                float u = distToRiver / riverChannelWidth; // 0=centre, 1=bank
-                h = riverFloor + channelDepth * u * u;     // set exactly, don't min
+                // Inside channel: deep parabolic U-shape
+                // Near-vertical walls at edge give terrain normals with large
+                // X component → strong lateral containment from terrain constraint
+                float u = distToRiver / riverChannelWidth;
+                h = riverFloor + channelDepth * u * u;
             } else {
-                // Outside channel: raise terrain to create a genuine physical wall.
-                // Without this, noise dips can make the bank lower than the channel
-                // edge and the terrain constraint provides zero lateral containment.
-                float wallBase = channelEdge + 1.5f;
-                float pastBank = std::min((distToRiver - riverChannelWidth) * 1.5f, 2.0f);
-                h = std::max(h, wallBase + pastBank);
+                // Outside channel: keep plateau, ensure it's always above channel edge
+                h = std::max(h, channelEdge + 0.3f);
             }
 
             // Don't punch through the box floor
@@ -737,9 +736,11 @@ void SPHFluidGPU::GenerateRiverTerrain(int seed) {
         }
     }
 
-    // Position emitter at the upstream mouth of the channel
-    float startX = param_boxCenter.x + riverAmp * std::sinf(riverPhase);
-    riverEmitterPos    = Vec3(startX, yBase + 2.5f, zMin + 0.4f);
+    // Position emitter at the upstream mouth of the channel, above the floor
+    float emitterZ  = zMin + 0.5f;
+    float startX    = param_boxCenter.x + riverAmp * std::sinf(riverFreq * emitterZ + riverPhase);
+    float floorUp   = yBase + 1.0f; // upstream floor
+    riverEmitterPos = Vec3(startX, floorUp + channelDepth * 0.5f, emitterZ);
     riverEmitterVel    = Vec3(0.0f, -0.5f, 0.5f);   // channel constraint steers flow
     riverEmitterRadius = riverChannelWidth * 0.35f;
     riverSinkY         = yBase + 0.3f;               // just above box floor — recycled when they hit bottom

--- a/ComponentFramework/shaders/ChannelConstraint.comp
+++ b/ComponentFramework/shaders/ChannelConstraint.comp
@@ -28,27 +28,20 @@ void main() {
     float cx  = boxCenterX + riverAmp * sin(riverFreq * wz + riverPhase);
     float dx  = p.pos.x - cx;
 
-    // Tangent-following gravity — steer around bends
+    // Tangent-following gravity: push along the channel curve, not straight Z
     float tdx  = riverAmp * riverFreq * cos(riverFreq * wz + riverPhase);
     float tlen = sqrt(tdx * tdx + 1.0);
     vec2  tXZ  = vec2(tdx, 1.0) / tlen;
     p.vel.x += tXZ.x * flowGravity * timeStep;
     p.vel.z += tXZ.y * flowGravity * timeStep;
 
-    // Direct position correction toward centreline (unconditionally stable,
-    // analogous to terrain/OBB position snaps — no spring oscillation)
-    float corrRate = 0.20; // pull 20% of lateral error toward centre each step
-    p.pos.x -= dx * corrRate;
-
-    // Kill velocity component pointing away from centreline
-    // so pressure forces can't continually drive particles outward
-    if (dx * p.vel.x > 0.0) p.vel.x *= 0.05;
-
-    // Hard wall at exact bank edge (absolute containment)
-    float dxNew = p.pos.x - cx;
-    if (abs(dxNew) > channelWidth) {
-        p.pos.x = cx + sign(dxNew) * channelWidth;
-        p.vel.x = 0.0;
+    // Hard lateral wall at channel boundary ONLY.
+    // No centering spring — that collapsed all particles to a line.
+    // SPH pressure naturally distributes particles across the channel width.
+    // The parabolic terrain walls provide physical containment inside the channel.
+    if (abs(dx) > channelWidth) {
+        p.pos.x = cx + sign(dx) * channelWidth;
+        if (dx * p.vel.x > 0.0) p.vel.x = 0.0;
     }
 
     particles[i] = p;


### PR DESCRIPTION
## What was broken

**V-bowl terrain**: `wallBase + pastBank` raised the entire landscape surrounding the channel to an extreme height, turning the scene into a massive valley bowl with no natural terrain.

**Fluid condensing to a line**: `p.pos.x -= dx * 0.20` pulled every particle 20% of the way toward the channel centerline `cx` *every step* — even particles already inside the channel. This collapsed the fluid to a 1-particle-wide column through the center.

**Jagged bank lines**: the lines were sampling the distorted bowl terrain.

## Fixes

### Terrain rebuilt as plateau + deep carved U-channel
- **Background**: flat plateau at `yBase + 5.5` with gentle low-amplitude noise (±0.5 units) — looks like a flat landscape with the channel cut into it
- **Channel**: deep parabolic U-shape (depth 3.5–4.5 units), set explicitly so the shape is always correct
- **Containment**: at the channel edge (`u=1`) the parabolic wall slope is `2·depth/width ≈ 3–4:1`, giving a terrain normal with X component ≈ 0.94 — very strong lateral push back into channel from the terrain constraint alone
- **Outside channel**: plateau enforced `≥ channelEdge + 0.3` to guarantee the bank is always above the carved floor

### Channel constraint simplified
Removed `corrRate = 0.20` centering spring. Now only:
1. **Tangent gravity** (steers around bends)
2. **Hard wall** at `channelWidth` (absolute containment)

SPH pressure naturally distributes fluid across the channel width; steep terrain walls contain it laterally.

### Smaller meander
Amplitude reduced `1.5–4.0 → 0.5–2.0`, width `2.5–4.5 → 1.8–3.0` — channel stays well inside the box and the meander is visible but not extreme.

## Test plan
- [ ] Generate New River — terrain looks like a flat landscape with a channel carved in, not a bowl
- [ ] Red bank lines follow the channel smoothly (no zigzag)
- [ ] Fluid fills the channel width (not a thin line)
- [ ] Fluid follows the sinusoidal meander
- [ ] SSFR depth shading visible (darker = deeper)

https://claude.ai/code/session_01Go9qCcRduJaYgAo1duxc2z