### PR TITLE
Improve terrain edges: trapezoidal channel, edge fade, analytical bank lines

### DIFF
--- a/ComponentFramework/SPHFluid3D.cpp
+++ b/ComponentFramework/SPHFluid3D.cpp
@@ -673,17 +673,20 @@ void SPHFluidGPU::GenerateRiverTerrain(int seed) {
     riverFreq         = 0.18f + frand() * 0.18f;
     riverPhase        = frand() * 6.2831f;
     riverChannelWidth = 1.8f + frand() * 1.2f;     // 1.8-3.0 unit half-width
-    float channelDepth = 3.5f + frand() * 1.0f;    // deep U-shape: steep parabolic walls
-    float slopeDrop    = 0.3f + frand() * 0.5f;    // gentle downstream slope
+    riverChannelDepth = 3.5f + frand() * 1.0f;
+    riverSlopeDrop    = 0.3f + frand() * 0.5f;
+    float channelDepth = riverChannelDepth;
+    float slopeDrop    = riverSlopeDrop;
 
     // Noise phase seeds for the surrounding terrain
     float ph[8];
     for (int k = 0; k < 8; ++k) ph[k] = frand() * 6.2831f;
 
-    // Match terrain footprint to simulation box (elongated for river)
-    terrainWorldMinX  = param_boxCenter.x - param_boxHalf.x;
+    // Terrain footprint: extend 4 units beyond box in X to hide cliff edges
+    const float edgeExtent = 4.0f;
+    terrainWorldMinX  = param_boxCenter.x - param_boxHalf.x - edgeExtent;
     terrainWorldMinZ  = param_boxCenter.z - param_boxHalf.z;
-    terrainWorldSizeX = 2.0f * param_boxHalf.x;
+    terrainWorldSizeX = 2.0f * param_boxHalf.x + 2.0f * edgeExtent;
     terrainWorldSizeZ = 2.0f * param_boxHalf.z;
 
     float xMin   = terrainWorldMinX;
@@ -719,18 +722,38 @@ void SPHFluidGPU::GenerateRiverTerrain(int seed) {
             h += 0.12f * std::sinf(wx * 1.40f + ph[4]) * std::cosf(wz * 1.20f + ph[5]);
 
             if (distToRiver < riverChannelWidth) {
-                // Inside channel: deep parabolic U-shape
-                // Near-vertical walls at edge give terrain normals with large
-                // X component → strong lateral containment from terrain constraint
+                // Trapezoidal channel: flat floor (inner 50%) + parabolic walls (outer 50%)
+                // Flat floor makes depth visible; steep walls give strong lateral containment
                 float u = distToRiver / riverChannelWidth;
-                h = riverFloor + channelDepth * u * u;
+                const float floorFrac = 0.50f;
+                if (u < floorFrac) {
+                    h = riverFloor;
+                } else {
+                    float uw = (u - floorFrac) / (1.0f - floorFrac);
+                    h = riverFloor + channelDepth * uw * uw;
+                }
             } else {
                 // Outside channel: keep plateau, ensure it's always above channel edge
                 h = std::max(h, channelEdge + 0.3f);
             }
 
-            // Don't punch through the box floor
-            h = std::max(h, yBase - 0.3f);
+            // Edge fade: terrain tapers below box floor outside box X bounds
+            // This eliminates the sharp cliff face at the terrain X boundary
+            const float boxMinX = param_boxCenter.x - param_boxHalf.x;
+            const float boxMaxX = param_boxCenter.x + param_boxHalf.x;
+            float edgeFade = 0.0f;
+            if (wx < boxMinX) {
+                float t = std::min(1.0f, (boxMinX - wx) / edgeExtent);
+                edgeFade = t * t * (3.0f - 2.0f * t); // smoothstep
+            } else if (wx > boxMaxX) {
+                float t = std::min(1.0f, (wx - boxMaxX) / edgeExtent);
+                edgeFade = t * t * (3.0f - 2.0f * t);
+            }
+            h = h * (1.0f - edgeFade) + (yBase - 0.5f) * edgeFade;
+
+            // Don't punch through the box floor (only for in-box area)
+            if (wx >= boxMinX && wx <= boxMaxX)
+                h = std::max(h, yBase - 0.3f);
 
             terrainHeights[iz * terrainW + ix] = h;
         }

--- a/ComponentFramework/SPHFluid3D.h
+++ b/ComponentFramework/SPHFluid3D.h
@@ -125,10 +125,12 @@ public:
     float riverSinkZMax      =  9.0f;
 
     // Stored per-generation values (used during InitializeParticles)
-    float riverAmp   = 2.0f;
-    float riverFreq  = 0.25f;
-    float riverPhase = 0.0f;
+    float riverAmp          = 2.0f;
+    float riverFreq         = 0.25f;
+    float riverPhase        = 0.0f;
     float riverChannelWidth = 3.0f;
+    float riverChannelDepth = 3.5f;
+    float riverSlopeDrop    = 0.3f;
 
     GLuint terrainSSBO             = 0;
     GLuint terrainConstraintShader = 0;

--- a/ComponentFramework/Scene0p.cpp
+++ b/ComponentFramework/Scene0p.cpp
@@ -965,38 +965,37 @@ void Scene0p::BuildRiverBankLines() {
     const int N     = 300;
     const float zMin  = fluidGPU->terrainWorldMinZ;
     const float zSize = fluidGPU->terrainWorldSizeZ;
-    const float xMin  = fluidGPU->terrainWorldMinX;
-    const float xSize = fluidGPU->terrainWorldSizeX;
-    const int   TW    = fluidGPU->terrainW;
-    const int   TH    = fluidGPU->terrainH;
 
-    auto sampleH = [&](float wx, float wz) -> float {
-        float u = (wx - xMin) / xSize * float(TW - 1);
-        float v = (wz - zMin) / zSize * float(TH - 1);
-        u = std::max(0.0f, std::min(float(TW - 2), u));
-        v = std::max(0.0f, std::min(float(TH - 2), v));
-        int ix = int(u), iz = int(v);
-        float fx = u - ix, fz = v - iz;
-        float h00 = fluidGPU->terrainHeights[ ix      +  iz      * TW];
-        float h10 = fluidGPU->terrainHeights[(ix + 1) +  iz      * TW];
-        float h01 = fluidGPU->terrainHeights[ ix      + (iz + 1) * TW];
-        float h11 = fluidGPU->terrainHeights[(ix + 1) + (iz + 1) * TW];
-        return h00*(1-fx)*(1-fz) + h10*fx*(1-fz) + h01*(1-fx)*fz + h11*fx*fz;
-    };
+    // Analytical terrain parameters for smooth bank line heights
+    const float yBase        = fluidGPU->param_boxCenter.y - fluidGPU->param_boxHalf.y;
+    const float channelDepth = fluidGPU->riverChannelDepth;
+    const float slopeDrop    = fluidGPU->riverSlopeDrop;
 
     // 3 strips: 0=left bank, 1=right bank, 2=centerline
     std::vector<float> verts;
     verts.reserve(N * 3 * 3);
     for (int strip = 0; strip < 3; ++strip) {
         for (int i = 0; i < N; ++i) {
-            float wz = zMin + (float(i) / float(N - 1)) * zSize;
-            float cx = fluidGPU->param_boxCenter.x
-                     + fluidGPU->riverAmp * std::sinf(fluidGPU->riverFreq * wz + fluidGPU->riverPhase);
+            float wz    = zMin + (float(i) / float(N - 1)) * zSize;
+            float tFlow = (wz - zMin) / zSize;
+            float cx    = fluidGPU->param_boxCenter.x
+                        + fluidGPU->riverAmp * std::sinf(fluidGPU->riverFreq * wz + fluidGPU->riverPhase);
+
             float wx;
-            if      (strip == 0) wx = cx - fluidGPU->riverChannelWidth;
-            else if (strip == 1) wx = cx + fluidGPU->riverChannelWidth;
-            else                 wx = cx;
-            float wy = sampleH(wx, wz) + 0.06f; // slight lift to avoid z-fighting
+            float wy;
+            if (strip == 0 || strip == 1) {
+                // Bank edge: top of channel wall (channel floor + full depth)
+                wx = (strip == 0) ? cx - fluidGPU->riverChannelWidth
+                                  : cx + fluidGPU->riverChannelWidth;
+                float riverFloor = yBase + 1.0f - tFlow * slopeDrop;
+                wy = riverFloor + channelDepth + 0.12f; // slight lift above wall top
+            } else {
+                // Centerline: at water surface level (near channel floor)
+                wx = cx;
+                float riverFloor = yBase + 1.0f - tFlow * slopeDrop;
+                wy = riverFloor + 0.15f; // just above the flat channel floor
+            }
+
             verts.push_back(wx);
             verts.push_back(wy);
             verts.push_back(wz);


### PR DESCRIPTION
## Summary

- **Terrain edge fade**: Extended terrain footprint 4 units beyond the box on each X side with a smoothstep fade — eliminates the sharp vertical cliff faces at the terrain boundaries, replaced by natural tapering slopes
- **Trapezoidal channel profile**: Inner 50% of channel width is now a flat floor at `riverFloor`, outer 50% has steep parabolic walls rising to `channelEdge` — river depth is clearly visible instead of the previous V-shaped bowl
- **Analytical bank lines**: Red bank lines and orange centerline are now computed from `riverFloor + channelDepth` directly rather than sampling the terrain heightfield, removing the jitter/jaggedness at the channel edge

## Test plan

- [ ] Launch the simulation in river mode — terrain should extend visibly beyond the box walls with a gentle slope instead of cliff faces
- [ ] Look down into the channel — should see a flat river floor with steep walls on either side
- [ ] Bank lines (red left/right, orange center) should be smooth curves with no jitter
- [ ] Regenerate river with different seeds — edge fade and trapezoidal profile should apply to all seeds
- [ ] Confirm fluid still flows and is contained within the channel

https://claude.ai/code/session_01Go9qCcRduJaYgAo1duxc2z