### PR TITLE
Fix /sdl build error from stb_image_write's sprintf

### DIFF
--- a/ComponentFramework/stb_image_write_impl.cpp
+++ b/ComponentFramework/stb_image_write_impl.cpp
@@ -1,2 +1,5 @@
+// stb's HDR writer calls plain sprintf, which MSVC's /sdl flag elevates to an
+// error (C4996). Suppress the CRT deprecation for this third-party TU only.
+#define _CRT_SECURE_NO_WARNINGS
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "stb_image_write.h"


### PR DESCRIPTION
Follow-up to #14, which was merged before this fix landed.

Building with the project's `/sdl` flag failed with:

> 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead.

The call comes from the vendored `stb_image_write.h` (its HDR writer uses plain `sprintf`; MSVC never defines `__STDC_LIB_EXT1__`, so the `sprintf_s` branch is not taken). This defines `_CRT_SECURE_NO_WARNINGS` at the top of `stb_image_write_impl.cpp` — the only file that compiles the stb implementation — so the suppression stays scoped to the third-party code and the rest of the project keeps full `/sdl` checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKYgaEY7RgrspUijrDPPVe

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKYgaEY7RgrspUijrDPPVe)_