### PR TITLE
Default the water backdrop to black (sky stays in reflections)

### DIFF
--- a/ComponentFramework/Scene0p.cpp
+++ b/ComponentFramework/Scene0p.cpp
@@ -548,9 +548,11 @@ void Scene0p::Update(const float deltaTime) {
         ImGui::Separator(); ImGui::Text("Background");
         ImGui::ColorEdit3("Background", bgColor);
         if (useWaterRendering) {
+            ImGui::Checkbox("Sky Background", &showSkyBackground);
             ImGui::ColorEdit3("Sky Horizon", skyColor);
             ImGui::ColorEdit3("Sky Zenith", skyZenith);
             ImGui::ColorEdit3("Reflect Tint", envReflectColor);
+            ImGui::TextDisabled("Sky colors always drive the water's reflections;\nthe checkbox only draws them as the backdrop.");
         }
         if (useWaterRendering && ImGui::TreeNode("Water Surface Detail")) {
             if (ImGui::Checkbox("Half-Res Fluid (faster)", &ssfrHalfRes) && windowW > 0)
@@ -999,12 +1001,17 @@ void Scene0p::RenderSSFR(GLuint targetFBO, const Matrix4& proj) const {
     // -----------------------------------------------------------------------
     glBindFramebuffer(GL_FRAMEBUFFER, ssfrBgFBO);
     glViewport(0, 0, ssfrW, ssfrH);
-    glClearColor(skyColor[0], skyColor[1], skyColor[2], 1.0f);
+    // Backdrop: flat color by default (fluid reads much better on black);
+    // the sky gradient stays available for reflections either way.
+    if (showSkyBackground)
+        glClearColor(skyColor[0], skyColor[1], skyColor[2], 1.0f);
+    else
+        glClearColor(bgColor[0], bgColor[1], bgColor[2], 1.0f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     glDisable(GL_BLEND);
 
     // Procedural sky gradient behind everything (no depth writes)
-    if (skyShader) {
+    if (showSkyBackground && skyShader) {
         glDisable(GL_DEPTH_TEST);
         glDepthMask(GL_FALSE);
         glUseProgram(skyShader->GetProgram());

--- a/ComponentFramework/Scene0p.h
+++ b/ComponentFramework/Scene0p.h
@@ -72,8 +72,9 @@ private:
     float   iridShift    = 0.0f;
     float   duoColorA[3] = {0.05f, 0.02f, 0.10f};
     float   duoColorB[3] = {1.00f, 0.35f, 0.75f};
-    float   bgColor[3]   = {0.0f, 0.0f, 0.0f};              // clear color, impostor/mesh paths
-    float   skyColor[3]  = {0.40f, 0.55f, 0.65f};           // sky horizon color
+    bool    showSkyBackground = false;                      // false = flat bgColor backdrop (water pops on black)
+    float   bgColor[3]   = {0.0f, 0.0f, 0.0f};              // backdrop clear color (all render paths)
+    float   skyColor[3]  = {0.40f, 0.55f, 0.65f};           // sky horizon color (reflections + optional backdrop)
     float   skyZenith[3] = {0.15f, 0.28f, 0.50f};           // sky zenith color
     float   envReflectColor[3] = {0.90f, 0.95f, 1.00f};     // tint on the reflected sky
     float   foamAmount   = 1.5f;


### PR DESCRIPTION
Follow-up to #16, which was merged before this landed.

The pale sky gradient washed the fluid out. The background pass now clears with the **Background** color (default black, still a picker) and only draws the sky gradient when the new **Sky Background** checkbox is on. The sky colors keep driving the water's reflections either way, so the fluid stays lit and glassy against the dark backdrop — dark water, bright reflections.

Tuning tips on black: push **Deep Water Color** / **Thickness Scale** for more body color, and treat **Sun Color** + **Sky Horizon/Zenith** as the studio lights for the reflections.

