### PR TITLE
Stabilize the solver (kill jitter) and make sea foam visible

### DIFF
--- a/ComponentFramework/SPHFluid3D.cpp
+++ b/ComponentFramework/SPHFluid3D.cpp
@@ -515,7 +515,10 @@ void SPHFluidGPU::DispatchCompute(float overrideDt) {
     glUniform1f(glGetUniformLocation(sphGridShader, "surfaceTension"), param_surfaceTension);
     glUniform3f(glGetUniformLocation(sphGridShader, "gridMin"), gridMinV.x, gridMinV.y, gridMinV.z);
     glUniform1f(glGetUniformLocation(sphGridShader, "foamGen"), param_foamGen);
-    glUniform1f(glGetUniformLocation(sphGridShader, "foamVelRef"), 6.0f);
+    glUniform1f(glGetUniformLocation(sphGridShader, "foamVelRef"), param_foamVelRef);
+    // CFL-style cap: a particle may not cross more than ~0.4 smoothing lengths
+    // per substep. Kills the integration spikes that read as jitter.
+    glUniform1f(glGetUniformLocation(sphGridShader, "maxSpeed"), 0.4f * param_h / std::max(timeStep, 1e-6f));
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, ssbo);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, cellHeadSSBO);
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 2, particleNextSSBO);

--- a/ComponentFramework/SPHFluid3D.h
+++ b/ComponentFramework/SPHFluid3D.h
@@ -98,7 +98,8 @@ public:
     bool  param_useJitter = true;
     float param_jitterAmp = 0.20f;
 
-    float param_foamGen = 1.0f;   // foam generation scale (0 disables)
+    float param_foamGen = 1.0f;      // foam generation scale (0 disables)
+    float param_foamVelRef = 8.0f;   // speed where foam generation saturates
 
     bool  param_enableGhosts = false;
     bool  param_enableSort = false;

--- a/ComponentFramework/Scene0p.cpp
+++ b/ComponentFramework/Scene0p.cpp
@@ -576,8 +576,10 @@ void Scene0p::Update(const float deltaTime) {
             ImGui::SliderFloat("Fresnel Bias",      &fresnelBias,         0.0f,  0.3f);
             ImGui::Separator();
             ImGui::SliderFloat("Foam Generation",   &fluidGPU->param_foamGen, 0.0f, 2.0f);
+            ImGui::SliderFloat("Foam Threshold",    &fluidGPU->param_foamVelRef, 1.0f, 30.0f);
             ImGui::SliderFloat("Foam Amount",       &foamAmount,          0.0f,  4.0f);
             ImGui::SliderFloat("Exposure",          &exposure,            0.25f, 4.0f);
+            ImGui::TextDisabled("Lower Foam Threshold = foam appears at gentler motion.");
             ImGui::TreePop();
         }
         ImGui::PopID();

--- a/ComponentFramework/Scene0p.h
+++ b/ComponentFramework/Scene0p.h
@@ -138,11 +138,11 @@ private:
 
     bool    useWaterRendering   = true;
     int     smoothIterations    = 5;
-    float   worldFilterScale    = 4.0f;   // smoothing kernel width, in particle radii
-    float   surfaceMerge        = 2.0f;   // narrow-range band, in particle radii
+    float   worldFilterScale    = 6.0f;   // smoothing kernel width, in particle radii
+    float   surfaceMerge        = 3.0f;   // narrow-range band, in particle radii
     float   thicknessStrength   = 0.05f;
     float   thicknessFalloff    = 4.0f;
-    float   renderRadiusScale   = 1.0f;   // visual particle size multiplier (physics untouched)
+    float   renderRadiusScale   = 1.3f;   // visual particle size multiplier (physics untouched)
     float   waterExtinction[3]  = {0.45f, 0.15f, 0.05f};
     float   thicknessScale      = 1.0f;
     float   sunDirWorld[3]      = {0.4f, 1.0f, 0.5f};

--- a/ComponentFramework/shaders/SPHFluid.comp
+++ b/ComponentFramework/shaders/SPHFluid.comp
@@ -36,6 +36,7 @@ uniform float surfaceTension; // Tunable from CPU
 uniform int numParticles; // total particle count
 uniform float foamGen;    // foam generation scale (0 disables)
 uniform float foamVelRef; // speed at which foam generation saturates
+uniform float maxSpeed;   // CFL-style velocity cap (stability)
 
 // ----------- SPH Kernels -----------
 float poly6(float r2, float h) {
@@ -105,7 +106,9 @@ void main() {
     pi.density = density;
 
     // ---------- Pressure ----------
-    pi.pressure = gasConstant * (pi.density - restDensity);
+    // Clamped non-negative: negative (attractive) pressure at the free surface
+    // is the main source of particle jitter in weakly-compressible SPH.
+    pi.pressure = max(gasConstant * (pi.density - restDensity), 0.0);
 
     // ---------- Forces ----------
     vec3 fPressure = vec3(0.0);
@@ -197,14 +200,20 @@ pi.pos.xyz += pi.vel.xyz * timeStep;
     if (norm > 0.0) xsph /= norm;
     pi.vel.xyz += xsphC * xsph;
 
+    // ---------- Velocity cap (CFL-style, kills integration spikes) ----------
+    {
+        float sp = length(pi.vel.xyz);
+        if (sp > maxSpeed) pi.vel.xyz *= maxSpeed / sp;
+    }
+
     // ---------- Foam factor (padA, consumed by the renderer) ----------
     // Aerated where density is depleted (free surface / splashes) AND moving
-    // fast; decays over time so foam lingers briefly after the splash.
+    // fast; decays slowly so foam lingers like real sea foam.
     {
         float speed = length(pi.vel.xyz);
         float aer = clamp((restDensity - pi.density) / restDensity, 0.0, 1.0)
                   * clamp(speed / max(foamVelRef, 1e-3), 0.0, 1.0);
-        pi.padA = max(aer * foamGen, pi.padA * 0.97);
+        pi.padA = max(aer * foamGen, pi.padA * 0.995);
     }
 
     // ---------- Write back ----------


### PR DESCRIPTION
Follow-up to #17, addressing the visible sphere bumps, particle jitter, and missing foam.

**Jitter (the big one):** pressure could go negative when a particle's density dipped below rest — negative pressure is *attractive*, so surface particles constantly tug at each other and vibrate. It's the classic weakly-compressible SPH artifact, now clamped to zero. On top of that, velocities get a CFL-style cap (max 0.4 smoothing lengths per substep) so integration spikes can't kick particles around. The fluid should settle calm and dense like the reference sim.

**Sphere bumps:** default smoothing scale and merge band raised, and the *render* radius bumped to 1.3× (physics untouched) so the impostor spheres overlap and melt together instead of reading through the surface.

**Sea foam:** the foam decay rate was tuned per-substep but there are ~16 substeps per frame — foam faded in a tenth of a second, which is why it never showed. Decay slowed to linger like real foam, and the generation speed threshold is now a **Foam Threshold** slider (lower = foam at gentler motion).

To chase the reference-photo particle look directly: Render Mode → Point Impostors, Palette → Turbo, Color Drive → Speed, Lit particles on.

