### PR TITLE
Six new palettes (Galaxy, Plasma, Chrome, Gold, Acid Rings, Aurora) + outline color/toggle

### DIFF
--- a/ComponentFramework/Scene0p.cpp
+++ b/ComponentFramework/Scene0p.cpp
@@ -444,6 +444,10 @@ void Scene0p::Update(const float deltaTime) {
             ImGui::DragFloat3("Euler XYZ", &fluidGPU->param_boxEulerDeg.x, 0.5f, -180.0f, 180.0f);
         ImGui::SliderFloat("Wall Restitution", &fluidGPU->param_wallRestitution, 0.0f, 1.0f);
         ImGui::SliderFloat("Wall Friction", &fluidGPU->param_wallFriction, 0.0f, 1.0f);
+        ImGui::Separator();
+        ImGui::Checkbox("Show Outline", &showContainerOutline);
+        if (showContainerOutline)
+            ImGui::ColorEdit3("Outline Color", containerOutlineColor);
         ImGui::TextDisabled("The sim grid follows container edits automatically;\nfluid is squeezed to stay inside as walls move.");
         ImGui::PopID();
     }
@@ -522,7 +526,8 @@ void Scene0p::Update(const float deltaTime) {
         }
         ImGui::Separator(); ImGui::Text("Color");
         ImGui::Combo("Palette", &paletteId,
-            "Classic Height\0Turbo\0Neon / Synthwave\0Fire / Lava\0Iridescent / Oil Slick\0Ice\0Vaporwave\0Toxic\0Duotone\0");
+            "Classic Height\0Turbo\0Neon / Synthwave\0Fire / Lava\0Iridescent / Oil Slick\0Ice\0Vaporwave\0Toxic\0Duotone\0"
+            "Galaxy / Nebula\0Plasma\0Chrome\0Molten Gold\0Acid Rings\0Aurora\0");
         ImGui::Combo("Color Drive", &vizMode,
             "Height\0Speed\0Pressure\0Density\0View Depth\0Velocity Direction\0Distance from Center\0Instance Color\0");
         ImGui::DragFloat("Range Min", &vizRangeMin, 0.1f);
@@ -532,7 +537,7 @@ void Scene0p::Update(const float deltaTime) {
             ImGui::ColorEdit3("Duotone A", duoColorA);
             ImGui::ColorEdit3("Duotone B", duoColorB);
         }
-        if (paletteId == 4) {
+        if (paletteId == 4 || paletteId == 13) {
             ImGui::SliderFloat("Irid Frequency", &iridFreq, 0.0f, 8.0f);
             ImGui::SliderFloat("Irid Shift",     &iridShift, 0.0f, 1.0f);
         }
@@ -682,11 +687,12 @@ void Scene0p::RenderSceneTo(GLuint targetFBO, int outW, int outH, const Matrix4&
 
     glPolygonMode(GL_FRONT_AND_BACK, drawInWireMode ? GL_LINE : GL_FILL);
 
-    if (lineShader && boxVAO) {
+    if (showContainerOutline && lineShader && boxVAO) {
         glUseProgram(lineShader->GetProgram());
         glUniformMatrix4fv(lineShader->GetUniformID("projectionMatrix"), 1, GL_FALSE, proj);
         glUniformMatrix4fv(lineShader->GetUniformID("viewMatrix"), 1, GL_FALSE, viewMatrix);
-        if (GLint col = lineShader->GetUniformID("uColor"); col != -1) glUniform3f(col, 0.85f, 0.95f, 1.0f);
+        if (GLint col = lineShader->GetUniformID("uColor"); col != -1)
+            glUniform3fv(col, 1, containerOutlineColor);
         glBindVertexArray(boxVAO);
         glLineWidth(1.5f);
         glDrawArrays(GL_LINES, 0, containerWireVerts);
@@ -748,6 +754,7 @@ void Scene0p::SetColorUniforms(Shader* s) const {
     if (GLint loc = s->GetUniformID("duoColorB");   loc != -1) glUniform3fv(loc, 1, duoColorB);
     if (GLint loc = s->GetUniformID("iridFreq");    loc != -1) glUniform1f(loc, iridFreq);
     if (GLint loc = s->GetUniformID("iridShift");   loc != -1) glUniform1f(loc, iridShift);
+    if (GLint loc = s->GetUniformID("animTime");    loc != -1) glUniform1f(loc, ballAnimTime);
     if (GLint loc = s->GetUniformID("litSphere");   loc != -1) glUniform1i(loc, litParticles ? 1 : 0);
     if (GLint loc = s->GetUniformID("sunDirWorld"); loc != -1) glUniform3fv(loc, 1, sunDirWorld);
     if (GLint loc = s->GetUniformID("sunColor");    loc != -1) glUniform3fv(loc, 1, sunColor);
@@ -1050,12 +1057,12 @@ void Scene0p::RenderSSFR(GLuint targetFBO, const Matrix4& proj) const {
         DrawRiverBankLines(proj);
 
     // Box wireframe (skip in river mode to reduce visual clutter)
-    if (lineShader && boxVAO && fluidGPU && !fluidGPU->riverMode) {
+    if (showContainerOutline && lineShader && boxVAO && fluidGPU && !fluidGPU->riverMode) {
         glUseProgram(lineShader->GetProgram());
         glUniformMatrix4fv(lineShader->GetUniformID("projectionMatrix"), 1, GL_FALSE, proj);
         glUniformMatrix4fv(lineShader->GetUniformID("viewMatrix"),       1, GL_FALSE, viewMatrix);
         if (GLint c = lineShader->GetUniformID("uColor"); c != -1)
-            glUniform3f(c, 0.6f, 0.75f, 1.0f);
+            glUniform3fv(c, 1, containerOutlineColor);
         glBindVertexArray(boxVAO);
         glLineWidth(1.5f);
         glDrawArrays(GL_LINES, 0, containerWireVerts);

--- a/ComponentFramework/Scene0p.h
+++ b/ComponentFramework/Scene0p.h
@@ -37,6 +37,8 @@ private:
     Shader* lineShader = nullptr;
     GLuint  boxVAO = 0, boxVBO = 0;
     int     containerWireVerts = 24;   // vertex count currently in boxVBO
+    bool    showContainerOutline = true;
+    float   containerOutlineColor[3] = {0.85f, 0.95f, 1.0f};
 
     bool    pendingReset = false;
     float   ballAnimTime = 0.0f;

--- a/ComponentFramework/shaders/defaultFrag.glsl
+++ b/ComponentFramework/shaders/defaultFrag.glsl
@@ -14,6 +14,7 @@ out vec4 outColor;
 uniform mat4  viewMatrix;
 uniform int   colorDrive;   // 0=Height 1=Speed 2=Pressure 3=Density 4=ViewDepth 5=VelocityDir 6=RadialDist 7=InstanceColor
 uniform int   paletteId;    // 0=Classic 1=Turbo 2=Neon 3=Fire 4=Iridescent 5=Ice 6=Vaporwave 7=Toxic 8=Duotone
+                             // 9=Galaxy 10=Plasma 11=Chrome 12=MoltenGold 13=AcidRings 14=Aurora
 uniform vec2  vizRange;
 uniform vec2  heightMinMax;
 uniform vec3  boxCenter;
@@ -21,6 +22,7 @@ uniform vec3  duoColorA;
 uniform vec3  duoColorB;
 uniform float iridFreq;
 uniform float iridShift;
+uniform float animTime;    // seconds, for time-animated palettes (e.g. Aurora)
 uniform float hueShift;     // degrees
 uniform float satMul;
 uniform float brightMul;
@@ -96,7 +98,29 @@ vec3 applyPalette(float t, float facing) {
                                         vec3(1.00, 0.55, 0.75), vec3(0.35, 0.95, 0.90)); // Vaporwave
     if (paletteId == 7) return ramp4(t, vec3(0.01, 0.03, 0.01), vec3(0.05, 0.35, 0.05),
                                         vec3(0.45, 0.95, 0.10), vec3(0.95, 1.00, 0.30)); // Toxic
-    return mix(duoColorA, duoColorB, t); // 8 = Duotone
+    if (paletteId == 8) return mix(duoColorA, duoColorB, t); // Duotone
+    if (paletteId == 9) return iqPal(t, vec3(0.20, 0.10, 0.35), vec3(0.35, 0.25, 0.55),
+                                        vec3(1.00, 1.20, 0.70), vec3(0.10, 0.35, 0.65))
+                              + vec3(0.10, 0.00, 0.25) * (1.0 - facing); // Galaxy / Nebula
+    if (paletteId == 10) {                                              // Plasma
+        float p = sin(t * 12.566 + facing * 6.2831853) * 0.5 + 0.5;
+        float q = sin(t * 8.377  - facing * 9.4248)    * 0.5 + 0.5;
+        return vec3(p, q, 1.0 - p * q);
+    }
+    if (paletteId == 11) {                                              // Chrome
+        vec3 base = mix(vec3(0.05), vec3(0.85), t);
+        return base + vec3(pow(1.0 - facing, 2.0));
+    }
+    if (paletteId == 12) {                                              // Molten Gold
+        vec3 base = ramp4(t, vec3(0.10, 0.04, 0.00), vec3(0.55, 0.28, 0.02),
+                              vec3(0.95, 0.65, 0.10), vec3(1.00, 0.92, 0.55));
+        return base + vec3(1.00, 0.95, 0.80) * pow(1.0 - facing, 2.5) * 0.6;
+    }
+    if (paletteId == 13) return iqPal(t * 3.0 + iridFreq * (1.0 - facing) * 2.0 + iridShift,
+                                      vec3(0.5), vec3(0.5), vec3(2.0, 3.0, 4.0),
+                                      vec3(0.00, 0.15, 0.35)); // Acid Rings
+    return iqPal(t + animTime * 0.15, vec3(0.15, 0.35, 0.35), vec3(0.25, 0.45, 0.45),
+                 vec3(0.80, 1.00, 1.20), vec3(0.25, 0.55, 0.85)); // 14 = Aurora
 }
 
 // Branchless RGB<->HSV (Sam Hocevar, public domain)

--- a/ComponentFramework/shaders/particleImpostor.frag
+++ b/ComponentFramework/shaders/particleImpostor.frag
@@ -12,6 +12,7 @@ out vec4 outColor;
 uniform mat4  viewMatrix;
 uniform int   colorDrive;   // 0=Height 1=Speed 2=Pressure 3=Density 4=ViewDepth 5=VelocityDir 6=RadialDist 7=InstanceColor
 uniform int   paletteId;    // 0=Classic 1=Turbo 2=Neon 3=Fire 4=Iridescent 5=Ice 6=Vaporwave 7=Toxic 8=Duotone
+                             // 9=Galaxy 10=Plasma 11=Chrome 12=MoltenGold 13=AcidRings 14=Aurora
 uniform vec2  vizRange;
 uniform vec2  heightMinMax;
 uniform vec3  boxCenter;
@@ -19,6 +20,7 @@ uniform vec3  duoColorA;
 uniform vec3  duoColorB;
 uniform float iridFreq;
 uniform float iridShift;
+uniform float animTime;    // seconds, for time-animated palettes (e.g. Aurora)
 uniform float hueShift;     // degrees
 uniform float satMul;
 uniform float brightMul;
@@ -94,7 +96,29 @@ vec3 applyPalette(float t, float facing) {
                                         vec3(1.00, 0.55, 0.75), vec3(0.35, 0.95, 0.90)); // Vaporwave
     if (paletteId == 7) return ramp4(t, vec3(0.01, 0.03, 0.01), vec3(0.05, 0.35, 0.05),
                                         vec3(0.45, 0.95, 0.10), vec3(0.95, 1.00, 0.30)); // Toxic
-    return mix(duoColorA, duoColorB, t); // 8 = Duotone
+    if (paletteId == 8) return mix(duoColorA, duoColorB, t); // Duotone
+    if (paletteId == 9) return iqPal(t, vec3(0.20, 0.10, 0.35), vec3(0.35, 0.25, 0.55),
+                                        vec3(1.00, 1.20, 0.70), vec3(0.10, 0.35, 0.65))
+                              + vec3(0.10, 0.00, 0.25) * (1.0 - facing); // Galaxy / Nebula
+    if (paletteId == 10) {                                              // Plasma
+        float p = sin(t * 12.566 + facing * 6.2831853) * 0.5 + 0.5;
+        float q = sin(t * 8.377  - facing * 9.4248)    * 0.5 + 0.5;
+        return vec3(p, q, 1.0 - p * q);
+    }
+    if (paletteId == 11) {                                              // Chrome
+        vec3 base = mix(vec3(0.05), vec3(0.85), t);
+        return base + vec3(pow(1.0 - facing, 2.0));
+    }
+    if (paletteId == 12) {                                              // Molten Gold
+        vec3 base = ramp4(t, vec3(0.10, 0.04, 0.00), vec3(0.55, 0.28, 0.02),
+                              vec3(0.95, 0.65, 0.10), vec3(1.00, 0.92, 0.55));
+        return base + vec3(1.00, 0.95, 0.80) * pow(1.0 - facing, 2.5) * 0.6;
+    }
+    if (paletteId == 13) return iqPal(t * 3.0 + iridFreq * (1.0 - facing) * 2.0 + iridShift,
+                                      vec3(0.5), vec3(0.5), vec3(2.0, 3.0, 4.0),
+                                      vec3(0.00, 0.15, 0.35)); // Acid Rings
+    return iqPal(t + animTime * 0.15, vec3(0.15, 0.35, 0.35), vec3(0.25, 0.45, 0.45),
+                 vec3(0.80, 1.00, 1.20), vec3(0.25, 0.55, 0.85)); // 14 = Aurora
 }
 
 // Branchless RGB<->HSV (Sam Hocevar, public domain)


### PR DESCRIPTION
## New palettes (Appearance → Palette, now 15 total)

The concentric rings you loved on Iridescent come from `facing` (view-angle) driving the palette lookup — it's radially symmetric on a sphere billboard, so it naturally rings. Leaned into that plus some new directions:

- **Galaxy / Nebula** — deep purple/blue/magenta multi-frequency cosine palette with a glow at the silhouette
- **Plasma** — the classic demoscene sine-interference look
- **Chrome** — desaturated ramp + a sharp facing-based rim highlight, reads as a mirror ball
- **Molten Gold** — warm bronze→gold ramp with the same metallic rim, warmer tone
- **Acid Rings** — Iridescent's ring trick pushed to a higher, per-channel frequency for a kaleidoscope/op-art pattern; shares the Irid Frequency/Shift sliders with Iridescent
- **Aurora** — time-animated, shifts continuously through green/blue/purple

## Container outline

New **Show Outline** checkbox + **Outline Color** picker in the Container panel. Toggling it off skips the wireframe draw entirely (both the plain render path and the water-surface background pass), and the color is now yours to pick instead of two slightly-different hardcoded blues.

## Verification

Both touched fragment shaders (particleImpostor.frag, defaultFrag.glsl — kept byte-identical in their shared palette block) compile and link under glslangValidator; Scene0p.cpp passes a full syntax check against stubbed external headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKYgaEY7RgrspUijrDPPVe

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKYgaEY7RgrspUijrDPPVe)_