### PR TITLE
Audio-reactive fluid: bass/mid/treble from system audio drive splashes + visuals

### DIFF
--- a/ComponentFramework/AudioReactive.cpp
+++ b/ComponentFramework/AudioReactive.cpp
@@ -1,0 +1,222 @@
+#include "AudioReactive.h"
+
+#include <cmath>
+#include <algorithm>
+
+// ---------------------------------------------------------------------------
+// Section A — band-split + envelope DSP (no Windows dependencies)
+//
+// One-pole filters, chosen over biquads because they are correct by
+// construction: the lowpass is the exact digital form of an RC filter and the
+// highpass is literally input minus lowpass. For driving splashes and color
+// pulses (not audio playback), the gentler rolloff is irrelevant.
+// ---------------------------------------------------------------------------
+namespace {
+
+// Per-sample smoothing coefficient for a one-pole lowpass at cutoff fcHz.
+float FilterAlpha(float fcHz, float fsHz) {
+    return 1.0f - std::exp(-6.2831853f * fcHz / fsHz);
+}
+
+// Per-sample coefficient for an envelope with time constant tcMs.
+float EnvelopeCoeff(float tcMs, float fsHz) {
+    return 1.0f - std::exp(-1000.0f / (std::max(tcMs, 0.1f) * fsHz));
+}
+
+float OnePoleLowpass(float x, float& state, float alpha) {
+    state += alpha * (x - state);
+    return state;
+}
+
+float OnePoleHighpass(float x, float& lpState, float alpha) {
+    return x - OnePoleLowpass(x, lpState, alpha);
+}
+
+// Attack/release peak-envelope follower.
+void UpdateEnvelope(float rectified, float& env, float attackCoeff, float releaseCoeff) {
+    float c = (rectified > env) ? attackCoeff : releaseCoeff;
+    env += c * (rectified - env);
+}
+
+struct BandState {
+    float lpBass = 0.0f, lpMidHi = 0.0f, lpMidLo = 0.0f, lpTreble = 0.0f;
+    float envBass = 0.0f, envMid = 0.0f, envTreble = 0.0f;
+};
+
+// Feeds one mono sample through the three band filters + envelope followers.
+void ProcessSample(float mono, BandState& s, float fs,
+                   float attackCoeff, float releaseCoeff) {
+    const float aBass   = FilterAlpha(150.0f,  fs);
+    const float aMidHi  = FilterAlpha(2000.0f, fs);
+    const float aMidLo  = FilterAlpha(250.0f,  fs);
+    const float aTreble = FilterAlpha(2800.0f, fs);
+
+    float bass   = OnePoleLowpass(mono, s.lpBass, aBass);
+    float midHi  = OnePoleLowpass(mono, s.lpMidHi, aMidHi);          // strip highs
+    float mid    = OnePoleHighpass(midHi, s.lpMidLo, aMidLo);        // then strip lows
+    float treble = OnePoleHighpass(mono, s.lpTreble, aTreble);
+
+    UpdateEnvelope(std::fabs(bass),   s.envBass,   attackCoeff, releaseCoeff);
+    UpdateEnvelope(std::fabs(mid),    s.envMid,    attackCoeff, releaseCoeff);
+    UpdateEnvelope(std::fabs(treble), s.envTreble, attackCoeff, releaseCoeff);
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Main-thread API
+// ---------------------------------------------------------------------------
+
+AudioReactive::~AudioReactive() {
+    Stop();
+}
+
+void AudioReactive::Start() {
+    if (running.load()) return;
+    stopRequested.store(false);
+    running.store(true);
+    captureThread = std::thread(&AudioReactive::CaptureThreadMain, this);
+}
+
+void AudioReactive::Stop() {
+    stopRequested.store(true);
+    if (captureThread.joinable()) captureThread.join();
+    running.store(false);
+    capturing.store(false);
+    bassLevel.store(0.0f);
+    midLevel.store(0.0f);
+    trebleLevel.store(0.0f);
+}
+
+std::string AudioReactive::GetStatusText() const {
+    std::lock_guard<std::mutex> lock(statusMutex);
+    return statusText;
+}
+
+void AudioReactive::SetStatus(const std::string& s) {
+    std::lock_guard<std::mutex> lock(statusMutex);
+    statusText = s;
+}
+
+// ---------------------------------------------------------------------------
+// Section B — WASAPI loopback capture thread (Windows Core Audio, COM)
+//
+// Loopback on the default RENDER endpoint captures whatever the computer is
+// playing, regardless of source app — no microphone, no "Stereo Mix" device.
+// Modeled on Microsoft's loopback-recording reference sample. A polling loop
+// is used instead of event-driven capture: loopback events are driven by the
+// render endpoint's activity and stop firing when nothing is playing, whereas
+// polling just sees empty packets and keeps running; shutdown is also simpler
+// (the stop flag is checked every wake).
+// ---------------------------------------------------------------------------
+
+#include <initguid.h>   // define the ksmedia GUIDs in this TU (no ksguid.lib needed)
+#include <windows.h>
+#include <mmdeviceapi.h>
+#include <audioclient.h>
+#include <mmreg.h>
+#include <ksmedia.h>
+
+void AudioReactive::CaptureThreadMain() {
+    // MTA: this thread has no message pump, which STA COM would require.
+    HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+    if (FAILED(hr)) { SetStatus("Error: CoInitializeEx failed"); running.store(false); return; }
+    struct ComGuard { ~ComGuard() { CoUninitialize(); } } comGuard;
+
+    IMMDeviceEnumerator* enumerator = nullptr;
+    IMMDevice*           device     = nullptr;
+    IAudioClient*        client     = nullptr;
+    IAudioCaptureClient* capture    = nullptr;
+    WAVEFORMATEX*        mixFmt     = nullptr;
+
+    auto cleanup = [&]() {
+        if (capture)    capture->Release();
+        if (client)     client->Release();
+        if (device)     device->Release();
+        if (enumerator) enumerator->Release();
+        if (mixFmt)     CoTaskMemFree(mixFmt);
+        capturing.store(false);
+    };
+
+    hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL,
+                          __uuidof(IMMDeviceEnumerator), (void**)&enumerator);
+    if (FAILED(hr)) { SetStatus("Error: audio subsystem unavailable"); cleanup(); return; }
+
+    hr = enumerator->GetDefaultAudioEndpoint(eRender, eConsole, &device);
+    if (FAILED(hr)) { SetStatus("Error: no default playback device"); cleanup(); return; }
+
+    hr = device->Activate(__uuidof(IAudioClient), CLSCTX_ALL, nullptr, (void**)&client);
+    if (FAILED(hr)) { SetStatus("Error: could not open audio device"); cleanup(); return; }
+
+    hr = client->GetMixFormat(&mixFmt);
+    if (FAILED(hr) || !mixFmt) { SetStatus("Error: no mix format"); cleanup(); return; }
+
+    const bool isFloat =
+        (mixFmt->wFormatTag == WAVE_FORMAT_IEEE_FLOAT) ||
+        (mixFmt->wFormatTag == WAVE_FORMAT_EXTENSIBLE &&
+         IsEqualGUID(reinterpret_cast<WAVEFORMATEXTENSIBLE*>(mixFmt)->SubFormat,
+                     KSDATAFORMAT_SUBTYPE_IEEE_FLOAT));
+    if (!isFloat) { SetStatus("Error: unsupported mix format"); cleanup(); return; }
+
+    const REFERENCE_TIME bufferDuration = 200 * 10000; // 200 ms in 100ns units
+    hr = client->Initialize(AUDCLNT_SHAREMODE_SHARED, AUDCLNT_STREAMFLAGS_LOOPBACK,
+                            bufferDuration, 0, mixFmt, nullptr);
+    if (FAILED(hr)) { SetStatus("Error: loopback init failed"); cleanup(); return; }
+
+    hr = client->GetService(__uuidof(IAudioCaptureClient), (void**)&capture);
+    if (FAILED(hr)) { SetStatus("Error: capture service failed"); cleanup(); return; }
+
+    hr = client->Start();
+    if (FAILED(hr)) { SetStatus("Error: capture start failed"); cleanup(); return; }
+
+    const float fs  = float(mixFmt->nSamplesPerSec);
+    const int   nCh = int(mixFmt->nChannels);
+    capturing.store(true);
+    SetStatus("Capturing (" + std::to_string(mixFmt->nSamplesPerSec) + " Hz)");
+
+    BandState state;
+
+    while (!stopRequested.load(std::memory_order_relaxed)) {
+        Sleep(10);
+
+        // Recompute per-packet so the UI sliders take effect live.
+        const float attackCoeff  = EnvelopeCoeff(attackMs.load(std::memory_order_relaxed),  fs);
+        const float releaseCoeff = EnvelopeCoeff(releaseMs.load(std::memory_order_relaxed), fs);
+
+        UINT32 packetLen = 0;
+        hr = capture->GetNextPacketSize(&packetLen);
+        while (SUCCEEDED(hr) && packetLen > 0) {
+            BYTE*  data = nullptr;
+            UINT32 numFrames = 0;
+            DWORD  flags = 0;
+            hr = capture->GetBuffer(&data, &numFrames, &flags, nullptr, nullptr);
+            if (FAILED(hr)) break;
+
+            const bool  silent  = (flags & AUDCLNT_BUFFERFLAGS_SILENT) != 0;
+            const float* samples = reinterpret_cast<const float*>(data);
+
+            for (UINT32 f = 0; f < numFrames; ++f) {
+                float mono = 0.0f;
+                if (!silent && samples) {
+                    for (int c = 0; c < nCh; ++c) mono += samples[f * nCh + c];
+                    mono /= float(nCh);
+                }
+                ProcessSample(mono, state, fs, attackCoeff, releaseCoeff);
+            }
+
+            // Clamped before publishing: a runaway amplitude fed into the SPH
+            // impulse pass could destabilize the solver.
+            const float g = gain.load(std::memory_order_relaxed);
+            bassLevel.store(std::min(4.0f, state.envBass * g),     std::memory_order_relaxed);
+            midLevel.store(std::min(4.0f, state.envMid * g),       std::memory_order_relaxed);
+            trebleLevel.store(std::min(4.0f, state.envTreble * g), std::memory_order_relaxed);
+
+            capture->ReleaseBuffer(numFrames);
+            hr = capture->GetNextPacketSize(&packetLen);
+        }
+    }
+
+    client->Stop();
+    cleanup();
+    SetStatus("Idle");
+}

--- a/ComponentFramework/AudioReactive.h
+++ b/ComponentFramework/AudioReactive.h
@@ -1,0 +1,47 @@
+#pragma once
+#include <thread>
+#include <atomic>
+#include <mutex>
+#include <string>
+
+/// Captures the computer's audio OUTPUT (whatever is playing through the
+/// speakers) via WASAPI loopback on a background thread, splits it into
+/// Bass / Mid / Treble envelopes, and publishes them as atomics for the
+/// main thread to read once per frame. No microphone, no extra libraries —
+/// just the Windows Core Audio API (needs ole32.lib).
+class AudioReactive {
+public:
+    AudioReactive() = default;
+    ~AudioReactive();                    // stops the capture thread if still running
+
+    // --- Main-thread API ---
+    void Start();                        // launches the capture thread; no-op if running
+    void Stop();                         // signals + joins the thread; safe if not running
+    bool IsRunning()   const { return running.load(std::memory_order_relaxed); }
+    bool IsCapturing() const { return capturing.load(std::memory_order_relaxed); }
+    std::string GetStatusText() const;   // "Idle" / "Capturing (48000 Hz)" / "Error: ..."
+
+    float GetBass()   const { return bassLevel.load(std::memory_order_relaxed); }
+    float GetMid()    const { return midLevel.load(std::memory_order_relaxed); }
+    float GetTreble() const { return trebleLevel.load(std::memory_order_relaxed); }
+
+    // Tunable from the UI while capturing; read by the audio thread per packet.
+    std::atomic<float> attackMs { 15.0f };
+    std::atomic<float> releaseMs{ 250.0f };
+    std::atomic<float> gain     { 1.0f };
+
+private:
+    void CaptureThreadMain();            // owns all COM objects as locals; never touches GL
+
+    std::thread        captureThread;
+    std::atomic<bool>  running      { false };
+    std::atomic<bool>  capturing    { false };
+    std::atomic<bool>  stopRequested{ false };
+    std::atomic<float> bassLevel  { 0.0f };
+    std::atomic<float> midLevel  { 0.0f };
+    std::atomic<float> trebleLevel{ 0.0f };
+
+    mutable std::mutex statusMutex;      // guards statusText only
+    std::string        statusText{ "Idle" };
+    void SetStatus(const std::string& s);
+};

--- a/ComponentFramework/ComponentFramework.vcxproj
+++ b/ComponentFramework/ComponentFramework.vcxproj
@@ -86,7 +86,7 @@
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>C:\GameDev\OpenGL\lib;C:\GameDev\SDL\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>SDL2.lib;SDL2_image.lib;SDL2main.lib;glew32.lib;glew32s.lib;opengl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>SDL2.lib;SDL2_image.lib;SDL2main.lib;glew32.lib;glew32s.lib;opengl32.lib;ole32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>
     </Link>
   </ItemDefinitionGroup>
@@ -128,6 +128,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="AudioReactive.cpp" />
     <ClCompile Include="Body.cpp" />
     <ClCompile Include="Debug.cpp" />
     <ClCompile Include="glad.c" />
@@ -151,6 +152,7 @@
     <ClCompile Include="Window.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="AudioReactive.h" />
     <ClInclude Include="Body.h" />
     <ClInclude Include="Debug.h" />
     <ClInclude Include="imconfig.h" />

--- a/ComponentFramework/Scene0p.cpp
+++ b/ComponentFramework/Scene0p.cpp
@@ -124,10 +124,14 @@ bool Scene0p::OnCreate() {
     vizRangeMin = 0.0f;
     vizRangeMax = 10.0f;
 
+    audioReactive = new AudioReactive();   // capture thread starts only when enabled
+
     return true;
 }
 
 void Scene0p::OnDestroy() {
+    // First: join the audio capture thread so it never outlives the scene.
+    if (audioReactive) { audioReactive->Stop(); delete audioReactive; audioReactive = nullptr; }
     if (sphere) { sphere->OnDestroy(); delete sphere; sphere = nullptr; }
     if (mesh) { mesh->OnDestroy(); delete mesh; mesh = nullptr; }
     if (shader) { shader->OnDestroy(); delete shader; shader = nullptr; }
@@ -478,6 +482,48 @@ void Scene0p::Update(const float deltaTime) {
         ImGui::PopID();
     }
 
+    if (ImGui::CollapsingHeader("Audio Reactive")) {
+        ImGui::PushID("AudioReactive");
+        ImGui::Checkbox("Enable", &audioReactiveEnabled);   // thread start/stop happens in Update()
+        ImGui::TextDisabled("%s", audioReactive->GetStatusText().c_str());
+        ImGui::TextDisabled("Reacts to whatever your computer is playing.");
+
+        if (ImGui::SliderFloat("Master Gain", &audioMasterGain, 0.0f, 4.0f))
+            audioReactive->gain.store(audioMasterGain);
+
+        ImGui::ProgressBar(std::min(1.0f, audioReactive->GetBass()),   ImVec2(-1.0f, 0.0f), "Bass");
+        ImGui::ProgressBar(std::min(1.0f, audioReactive->GetMid()),    ImVec2(-1.0f, 0.0f), "Mid");
+        ImGui::ProgressBar(std::min(1.0f, audioReactive->GetTreble()), ImVec2(-1.0f, 0.0f), "Treble");
+
+        ImGui::Separator(); ImGui::Text("Physical (splashes)");
+        ImGui::SliderFloat("Bass Force",       &audioBassForce,       0.0f, 30.0f);
+        ImGui::SliderFloat("Bass Threshold",   &audioBassThreshold,   0.0f, 1.0f);
+        ImGui::SliderFloat("Mid Force",        &audioMidForce,        0.0f, 30.0f);
+        ImGui::SliderFloat("Mid Threshold",    &audioMidThreshold,    0.0f, 1.0f);
+        ImGui::SliderFloat("Treble Force",     &audioTrebleForce,     0.0f, 30.0f);
+        ImGui::SliderFloat("Treble Threshold", &audioTrebleThreshold, 0.0f, 1.0f);
+
+        ImGui::Separator(); ImGui::Text("Visual (pulses)");
+        ImGui::SliderFloat("Size Kick (bass)", &audioSizeKick,    0.0f, 2.0f);
+        ImGui::SliderFloat("Shimmer (treble)", &audioShimmerKick, 0.0f, 2.0f);
+        ImGui::SliderFloat("Foam Kick (mid)",  &audioFoamKick,    0.0f, 2.0f);
+
+        if (ImGui::TreeNode("Advanced")) {
+            float atk = audioReactive->attackMs.load();
+            float rel = audioReactive->releaseMs.load();
+            if (ImGui::SliderFloat("Attack (ms)",  &atk, 1.0f, 100.0f)) audioReactive->attackMs.store(atk);
+            if (ImGui::SliderFloat("Release (ms)", &rel, 20.0f, 800.0f)) audioReactive->releaseMs.store(rel);
+            ImGui::SliderFloat("Bass Wavelength",    &audioBassWavelength,   1.0f, 30.0f);
+            ImGui::SliderFloat("Mid Wavelength",     &audioMidWavelength,    0.5f, 10.0f);
+            ImGui::SliderFloat("Treble Wavelength",  &audioTrebleWavelength, 0.2f, 3.0f);
+            ImGui::SliderFloat("Bass Phase Speed",   &audioBassPhaseSpeed,   0.0f, 10.0f);
+            ImGui::SliderFloat("Mid Rotation Speed", &audioMidRotSpeed,      0.0f, 5.0f);
+            ImGui::SliderFloat("Treble Phase Speed", &audioTreblePhaseSpeed, 0.0f, 30.0f);
+            ImGui::TreePop();
+        }
+        ImGui::PopID();
+    }
+
     if (ImGui::CollapsingHeader("River / Stream Mode")) {
         ImGui::PushID("River");
         bool wasRiver = fluidGPU->riverMode;
@@ -641,6 +687,50 @@ void Scene0p::Update(const float deltaTime) {
         fluidGPU->ApplyWaveImpulse(waveAmplitude, waveWavelength, wavePhase, dir, yBandMin, yBandMax);
     }
 
+    // --- Audio Reactive: each band hits the fluid somewhere different ---
+    if (audioReactiveEnabled && audioReactive) {
+        if (!audioReactive->IsRunning()) audioReactive->Start();
+
+        const float bass   = audioReactive->GetBass();
+        const float mid    = audioReactive->GetMid();
+        const float treble = audioReactive->GetTreble();
+
+        const Vec3  half      = fluidGPU->EffectiveHalf();
+        const float boxBottom = fluidGPU->param_boxCenter.y - half.y;
+        const float boxSpanY  = 2.0f * half.y;
+
+        audioBassPhase   += audioBassPhaseSpeed   * deltaTime;
+        audioMidPhase    += audioMidRotSpeed      * deltaTime;   // doubles as rotation angle
+        audioTreblePhase += audioTreblePhaseSpeed * deltaTime;
+
+        if (bass > audioBassThreshold) {
+            // Bass: broad upward heave from the lower part of the container
+            fluidGPU->ApplyWaveImpulse(audioBassForce * bass, audioBassWavelength, audioBassPhase,
+                Vec3(0, 1, 0), boxBottom, boxBottom + boxSpanY * 0.4f);
+        }
+        if (mid > audioMidThreshold) {
+            // Mid: horizontal push whose direction slowly rotates around Y,
+            // so hits come from different sides over time
+            Vec3 dir(std::cos(audioMidPhase), 0.0f, std::sin(audioMidPhase));
+            fluidGPU->ApplyWaveImpulse(audioMidForce * mid, audioMidWavelength, audioMidPhase, dir,
+                boxBottom + boxSpanY * 0.3f, boxBottom + boxSpanY * 0.7f);
+        }
+        if (treble > audioTrebleThreshold) {
+            // Treble: fast, fine ripple confined to the surface band
+            fluidGPU->ApplyWaveImpulse(audioTrebleForce * treble, audioTrebleWavelength, audioTreblePhase,
+                Vec3(0, 1, 0), boxBottom + boxSpanY * 0.6f, boxBottom + boxSpanY);
+        }
+
+        renderRadiusScaleLive = renderRadiusScale * (1.0f + audioSizeKick    * bass);
+        brightMulLive         = brightMul         * (1.0f + audioShimmerKick * treble);
+        foamAmountLive        = foamAmount        * (1.0f + audioFoamKick    * mid);
+    } else {
+        if (audioReactive && audioReactive->IsRunning()) audioReactive->Stop();
+        renderRadiusScaleLive = renderRadiusScale;
+        brightMulLive         = brightMul;
+        foamAmountLive        = foamAmount;
+    }
+
     const float fixedDt = std::max(1e-6f, fluidGPU->param_timeStep);
     dtAccumulator += deltaTime;
     const int cap = (deltaTime > 0.033f) ? std::min(8, maxSubstepsPerFrame) : maxSubstepsPerFrame;
@@ -719,7 +809,7 @@ void Scene0p::RenderSceneTo(GLuint targetFBO, int outW, int outH, const Matrix4&
         glUniform1i(useLoc, renderFromSSBO ? 1 : 0);
     SetColorUniforms(shader);
 
-    float particleRadius = std::max(0.02f, 0.5f * fluidGPU->param_h) * renderRadiusScale;
+    float particleRadius = std::max(0.02f, 0.5f * fluidGPU->param_h) * renderRadiusScaleLive;
     Matrix4 scaleMat = MMath::scale(particleRadius, particleRadius, particleRadius);
     glUniformMatrix4fv(shader->GetUniformID("modelMatrix"), 1, GL_FALSE, scaleMat);
 
@@ -765,7 +855,7 @@ void Scene0p::SetColorUniforms(Shader* s) const {
 void Scene0p::SetGradeUniforms(Shader* s) const {
     if (GLint loc = s->GetUniformID("hueShift");    loc != -1) glUniform1f(loc, hueShiftDeg);
     if (GLint loc = s->GetUniformID("satMul");      loc != -1) glUniform1f(loc, satMul);
-    if (GLint loc = s->GetUniformID("brightMul");   loc != -1) glUniform1f(loc, brightMul);
+    if (GLint loc = s->GetUniformID("brightMul");   loc != -1) glUniform1f(loc, brightMulLive);
     if (GLint loc = s->GetUniformID("contrastMul"); loc != -1) glUniform1f(loc, contrastMul);
     if (GLint loc = s->GetUniformID("invertColor"); loc != -1) glUniform1i(loc, invertColor ? 1 : 0);
 }
@@ -778,7 +868,7 @@ void Scene0p::DrawFluidImpostors(const Matrix4& proj, int outH) const {
     SetColorUniforms(impostorShader);
 
     if (GLint r = impostorShader->GetUniformID("particleRadius"); r != -1)
-        glUniform1f(r, std::max(0.02f, 0.5f * fluidGPU->param_h) * renderRadiusScale);
+        glUniform1f(r, std::max(0.02f, 0.5f * fluidGPU->param_h) * renderRadiusScaleLive);
     if (GLint r = impostorShader->GetUniformID("viewportH"); r != -1)
         glUniform1f(r, static_cast<float>(outH));
 
@@ -900,7 +990,7 @@ void Scene0p::DestroySSFRBuffers() {
 void Scene0p::RenderSSFR(GLuint targetFBO, const Matrix4& proj) const {
     if (!fluidGPU || ssfrW <= 0 || ssfrH <= 0) return;
 
-    const float radius = std::max(0.02f, 0.5f * fluidGPU->param_h) * renderRadiusScale;
+    const float radius = std::max(0.02f, 0.5f * fluidGPU->param_h) * renderRadiusScaleLive;
     const auto  nFluid = static_cast<GLsizei>(fluidGPU->GetNumFluids());
 
     glEnable(GL_PROGRAM_POINT_SIZE);
@@ -1116,7 +1206,7 @@ void Scene0p::RenderSSFR(GLuint targetFBO, const Matrix4& proj) const {
     glUniform3fv(ssfrCompositeShader->GetUniformID("envReflectColor"), 1, envReflectColor);
     glUniform3fv(ssfrCompositeShader->GetUniformID("skyHorizonColor"), 1, skyColor);
     glUniform3fv(ssfrCompositeShader->GetUniformID("skyZenithColor"),  1, skyZenith);
-    glUniform1f(ssfrCompositeShader->GetUniformID("foamAmount"), foamAmount);
+    glUniform1f(ssfrCompositeShader->GetUniformID("foamAmount"), foamAmountLive);
     glUniform1f(ssfrCompositeShader->GetUniformID("exposure"),   exposure);
     SetGradeUniforms(ssfrCompositeShader);
 

--- a/ComponentFramework/Scene0p.h
+++ b/ComponentFramework/Scene0p.h
@@ -9,6 +9,7 @@
 #include "Body.h"
 #include "Mesh.h"
 #include "Shader.h"
+#include "AudioReactive.h"
 #include <glad.h>
 #include <limits>
 using namespace MATH;
@@ -103,6 +104,30 @@ private:
     float   yBandMax       =  std::numeric_limits<float>::infinity();
     bool    continuousWave = false;
     float   wavePhase      = 0.0f;
+
+    // --- Audio Reactive (own phase accumulators, independent of manual Waves) ---
+    AudioReactive* audioReactive = nullptr;
+    bool    audioReactiveEnabled = false;
+    float   audioMasterGain      = 1.0f;
+
+    float   audioBassForce   = 8.0f,  audioBassThreshold   = 0.05f;
+    float   audioBassWavelength = 10.0f, audioBassPhaseSpeed = 1.5f,  audioBassPhase   = 0.0f;
+    float   audioMidForce    = 4.0f,  audioMidThreshold    = 0.05f;
+    float   audioMidWavelength  = 3.0f,  audioMidRotSpeed    = 1.2f,  audioMidPhase    = 0.0f;
+    float   audioTrebleForce = 1.5f,  audioTrebleThreshold = 0.05f;
+    float   audioTrebleWavelength = 1.0f, audioTreblePhaseSpeed = 14.0f, audioTreblePhase = 0.0f;
+
+    float   audioSizeKick    = 0.3f;   // bass -> particle render size
+    float   audioShimmerKick = 0.5f;   // treble -> brightness pulse
+    float   audioFoamKick    = 0.6f;   // mid -> foam boost
+
+    // "Live" values fed to the renderer each frame. The base members stay the
+    // user's pure slider settings; these are recomputed fresh every Update()
+    // (base, or base*(1+kick*envelope) when audio-reactive is on), so there is
+    // no compounding drift and no fighting the sliders.
+    float   renderRadiusScaleLive = 1.3f;
+    float   brightMulLive         = 1.0f;
+    float   foamAmountLive        = 1.5f;
 
     void    UpdateContainerWireframe();
     void    SetupImpostorVAO();


### PR DESCRIPTION
## What it does

Check **Enable** in the new **Audio Reactive** panel and the fluid reacts live to whatever your computer is playing — Spotify, your DAW, a browser tab, anything. No microphone involved: it captures the system output directly via WASAPI loopback on the default playback device.

Each frequency band hits the fluid somewhere different, so the motion tracks the song structure:
- **Bass** → broad upward heave from the bottom of the container (kick drums make the whole body of water jump)
- **Mid** → horizontal push whose direction slowly rotates around the container (synths/vocals slosh it from different sides)
- **Treble** → fast fine ripples across the surface band (hi-hats shimmer the surface)

Plus visual pulses on top (instant, no physics latency): bass kicks the particle render size, treble pulses brightness (works in all three render modes), mid boosts foam.

## The panel

Enable checkbox (capture thread only runs while enabled), status line, live **Bass/Mid/Treble meter bars** for tuning, Master Gain, per-band **Force** + **Threshold** sliders (threshold gates out the noise floor), the three visual kick sliders, and an Advanced node with attack/release times, wavelengths, and phase/rotation speeds.

## How it's built

- New `AudioReactive` class: background thread, COM/WASAPI loopback (MTA, polling capture — loopback events stop firing during silence, polling doesn't care), one-pole band filters + attack/release envelope followers, results published via atomics. Thread starts on enable, joins on disable/teardown. Adds `ole32.lib`.
- The band-split/envelope math is **numerically tested**: the shipped code was extracted verbatim and fed synthetic tones — 60 Hz lands in bass, 800 Hz in mid, 9 kHz in treble, attack/release honor their time constants, silence stays exactly zero (13/13 checks pass).
- Render-side values (`renderRadiusScale`, `brightMul`, `foamAmount`) gained `Live` siblings recomputed from your base slider each frame, so the audio modulation can never compound into your settings or fight the sliders.
- Physical side reuses the existing `ApplyWaveImpulse` compute pass — three additive dispatches per frame, negligible cost. Band values are clamped before reaching the solver.

## Heads-up for testing

The WASAPI/COM capture body is the one piece that couldn't be verified in the dev container (needs Windows) — everything around it is syntax-checked and the DSP is unit-tested. If the panel shows an `Error:` status on your machine, paste it back and I'll fix. Start with music that has a strong kick and watch the meter bars to dial in Gain/Thresholds.

